### PR TITLE
Sketch of Kademlia-based broadcasting

### DIFF
--- a/examples/Broadcast.hs
+++ b/examples/Broadcast.hs
@@ -111,10 +111,12 @@ makeBroadcaster transport n = do
         pure ()
     worker discovery bcast@(initiator, _) prng n sactions = do
         let (m :: Int, prng') = random prng
+        liftIO . putStrLn $ "Discovering"
         _ <- discoverPeers (K.kdDiscovery discovery)
         peers <- knownPeers (K.kdDiscovery discovery)
+        liftIO . putStrLn $ "Broadcasting " ++ show m
         initiator m sactions
-        delay (for 500000)
+        delay (for 5000000)
         worker discovery bcast prng' (n - 1) sactions
 
 forK :: [t] -> (t -> m () -> m ()) -> m () -> m ()

--- a/examples/Broadcast.hs
+++ b/examples/Broadcast.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecursiveDo           #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DataKinds             #-}
+
+import           Control.Monad                        (forM, forM_, when)
+import           Control.Monad.IO.Class               (liftIO)
+import           Data.Binary
+import qualified Data.ByteString.Char8                as B8
+import qualified Data.ByteString.Lazy                 as BL
+import qualified Data.Set                             as S
+import           Data.Map.Strict                      (Map)
+import qualified Data.Map.Strict                      as M
+import           Data.String                          (fromString)
+import           Data.Void                            (Void)
+import           Mockable.Concurrent                  (delay, for)
+import qualified Mockable.SharedAtomic                as SA
+import           Mockable.Production
+import           Network.Discovery.Abstract
+import qualified Network.Discovery.Transport.Kademlia as K
+import qualified Network.Kademlia                     as K (create, close)
+import           Network.Transport.Abstract           (newEndPoint)
+import           Network.Transport.Concrete           (concrete)
+import qualified Network.Transport.InMemory           as InMemory
+import qualified Network.Transport.TCP                as TCP
+import qualified Broadcast.Abstract                   as Broadcast
+import           Broadcast.Kademlia                   (kademliaBroadcast)
+import           Node
+import           System.Environment                   (getArgs)
+import           System.Random
+import           Data.Proxy                           (Proxy(Proxy))
+import           Data.Digest.Pure.SHA                 (sha1, bytestringDigest, showDigest)
+import           Message.Message                      (BinaryP(..))
+
+makeId i = K.makeKIdentifierPaddedTrimmed twenty (fromIntegral 0) (BL.toStrict (bytestringDigest (sha1 (BL.fromStrict (B8.pack (show i))))))
+    where
+    twenty :: Proxy 20
+    twenty = Proxy
+
+-- | Make a listener node. It will listen for and repeat a "ping" message.
+--   It will also update some shared state.
+makeListener transport sharedState i k = do
+    let port = 3000 + i
+    let host = "127.0.0.1"
+    let anId = makeId port
+    let initialPeer =
+            if i == 1
+            then K.Node (K.Peer host (fromIntegral 3001)) (makeId 3001)
+            else K.Node (K.Peer host (fromIntegral (3000 + (i - 1)))) (makeId (3000 + (i - 1)))
+    let prng = mkStdGen port
+    let hexId = showDigest (sha1 (BL.fromStrict (B8.pack (show port))))
+    liftIO . putStrLn $ "Spawning listener with identifier " ++ hexId
+    node transport prng BinaryP $ \node -> do
+        let localAddress = nodeEndPointAddress node
+        kademliaInstance <- liftIO $ K.create (fromIntegral port) anId
+        discovery <- K.kademliaDiscoveryExposeInternals kademliaInstance initialPeer localAddress
+        bcast <- kademliaBroadcast discovery (fromString "ping")
+        pure $ NodeAction [listener discovery bcast (nodeId node)] $ \_ -> do
+            k
+            liftIO $ putStrLn "Closing Kademlia"
+            closeDiscovery (K.kdDiscovery discovery)
+            liftIO $ K.close kademliaInstance
+    where
+    listener discovery (_, withRepeater) nid = withRepeater $ \repeater peerid sactions (body :: Int) -> do
+        liftIO . putStrLn $ show nid ++ " : " ++ show body
+        _ <- SA.modifySharedAtomic sharedState $ \map ->
+            -- Int overflow is expected. All we care about is that every value
+            -- in this map is eventually the same, which almost certainly
+            -- means that every node heard all of the broadcasts.
+            pure $ (M.alter (maybe (Just body) (Just . (+) body)) nid map, ())
+        _ <- discoverPeers (K.kdDiscovery discovery)
+        --peers <- knownPeers (K.kdDiscovery discovery)
+        --liftIO . putStrLn $ show nid ++ " : known peers are " ++ show peers
+        repeater
+
+-- | Make a broadcaster node. It will broadcast a "ping" to the network every
+--   second.
+makeBroadcaster transport n = do
+    let port = 3000
+    let host = "127.0.0.1"
+    let anId = makeId port
+    let initialPeer = K.Node (K.Peer host (fromIntegral (port + 1))) (makeId (port + 1))
+    let prng1 = mkStdGen port
+    let prng2 = mkStdGen (port + 1)
+    let hexId = showDigest (sha1 (BL.fromStrict (B8.pack (show port))))
+    liftIO . putStrLn $ "Spawning broadcaster with identifier " ++ hexId
+    node transport prng1 BinaryP $ \node -> do
+        let localAddress = nodeEndPointAddress node
+        kademliaInstance <- liftIO $ K.create (fromIntegral port) anId
+        discovery <- K.kademliaDiscoveryExposeInternals kademliaInstance initialPeer localAddress
+        bcast <- kademliaBroadcast discovery (fromString "ping")
+        pure $ NodeAction [] $ worker discovery bcast prng2 n 
+    where
+    worker _ _ _ 0 _ = do
+        -- When the broadcasts have stopped, we must wait for a while to let
+        -- them propagate (once this worker ends, the listeners will be brought
+        -- down).
+        --
+        -- This is a shame. TODO: some way to wait for all traffic to stop
+        -- before shutting down *any* node.
+        -- If there's any active handler, or any network-transport connection
+        -- open, then we can't stop yet.
+        liftIO . putStrLn $ "\n====\nEnd of broadcasts. Waiting 60 seconds.\n===\n"
+        delay (for 60000000)
+        pure ()
+    worker discovery bcast@(initiator, _) prng n sactions = do
+        let (m :: Int, prng') = random prng
+        _ <- discoverPeers (K.kdDiscovery discovery)
+        peers <- knownPeers (K.kdDiscovery discovery)
+        initiator m sactions
+        delay (for 500000)
+        worker discovery bcast prng' (n - 1) sactions
+
+forK :: [t] -> (t -> m () -> m ()) -> m () -> m ()
+forK [] _ k = k
+forK (t : ts) f k = f t (forK ts f k)
+
+main = runProduction $ do
+
+    [arg0, arg1] <- liftIO getArgs
+    let numberOfListeners = read arg0
+    let numberOfBroadcasts = read arg1
+
+    when (numberOfListeners < 1) $ error "Give a positive number of listeners"
+    when (numberOfBroadcasts < 1) $ error "Give a positive number of broadcasts"
+
+    Right transport_ <- liftIO $ TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
+    let transport = concrete transport_
+
+    sharedState <- SA.newSharedAtomic M.empty
+
+    liftIO . putStrLn $ "Spawning " ++ show numberOfListeners ++ " listener(s)"
+    forK [1..numberOfListeners] (makeListener transport sharedState) $ do
+
+        liftIO . putStrLn $ "Spawning a broadcaster"
+        makeBroadcaster transport numberOfBroadcasts
+
+        liftIO $ putStrLn "Stopping nodes"
+
+        finalState <- SA.modifySharedAtomic sharedState $ \map -> pure (map, map)
+        liftIO $ putStrLn "=== Final state is ==="
+        liftIO $ print finalState
+
+        let consistent = case M.toList finalState of
+                [] -> True
+                ((nodeId, value) : rest) -> all ((==) value . snd) rest
+
+        liftIO . putStrLn $ "Consistent : " ++ show consistent

--- a/examples/Broadcast.hs
+++ b/examples/Broadcast.hs
@@ -68,7 +68,7 @@ makeListener transport sharedState i k = do
             liftIO $ K.close kademliaInstance
     where
     listener discovery (_, withRepeater) nid = withRepeater $ \repeater peerid sactions (body :: Int) -> do
-        liftIO . putStrLn $ show nid ++ " : " ++ show body
+        --liftIO . putStrLn $ show nid ++ " : " ++ show body
         _ <- SA.modifySharedAtomic sharedState $ \map ->
             -- Int overflow is expected. All we care about is that every value
             -- in this map is eventually the same, which almost certainly

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DataKinds             #-}
 
 module Main where
 
@@ -32,6 +33,7 @@ import           Node
 import           Node.Message                         (BinaryP (..))
 import           System.Environment                   (getArgs)
 import           System.Random
+import           Data.Proxy                           (Proxy(Proxy))
 
 data Pong = Pong
 deriving instance Generic Pong
@@ -96,14 +98,14 @@ makeNode transport i = do
     fork $ node (simpleNodeEndPoint transport) prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
-            kademliaInstance <- liftIO $ K.create "127.0.0.1" (fromIntegral port) (K.KSerialize anId)
+            kademliaInstance <- liftIO $ K.create "127.0.0.1" (fromIntegral port) anId
             discovery <- K.kademliaDiscovery kademliaInstance initialPeer (nodeEndPointAddress node')
             worker (nodeId node') prng2 discovery sactions
                 `finally` (closeDiscovery discovery >> liftIO (K.close kademliaInstance))
     where
-    makeId anId
-        | anId < 10 = B8.pack ("node_identifier_0" ++ show anId)
-        | otherwise = B8.pack ("node_identifier_" ++ show anId)
+    makeId i = K.makeKIdentifierPaddedTrimmed twenty (fromIntegral 0) (B8.pack (show i))
+    twenty :: Proxy 20
+    twenty = Proxy
 
 main :: IO ()
 main = runProduction $ do

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -21,6 +21,9 @@ Library
 
                         Node
 
+                        Broadcast.Abstract
+                        Broadcast.Kademlia
+
                         Mockable
                         Mockable.Channel
                         Mockable.Class
@@ -106,6 +109,28 @@ executable discovery
                       , random
                       , time-units
                       , kademlia
+
+  hs-source-dirs:       examples
+  default-language:     Haskell2010
+  ghc-options:          -threaded -Wall -fno-warn-orphans
+  default-extensions:   DeriveDataTypeable
+                        DeriveGeneric
+                        GeneralizedNewtypeDeriving
+                        OverloadedStrings
+                        RecordWildCards
+
+executable broadcast
+  main-is:              Broadcast.hs
+  build-depends:        base >= 4.8 && < 5
+                      , binary
+                      , bytestring
+                      , containers
+                      , network-transport-inmemory
+                      , network-transport-tcp
+                      , node-sketch
+                      , random
+                      , kademlia
+                      , SHA
 
   hs-source-dirs:       examples
   default-language:     Haskell2010

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -105,6 +105,7 @@ executable discovery
                       , node-sketch
                       , random
                       , time-units
+                      , kademlia
 
   hs-source-dirs:       examples
   default-language:     Haskell2010

--- a/src/Broadcast/Abstract.hs
+++ b/src/Broadcast/Abstract.hs
@@ -1,0 +1,26 @@
+module Broadcast.Abstract (
+
+      Broadcast
+
+    , Initiator
+    , Repeater
+    , WithRepeater
+
+    ) where
+
+import Node
+
+-- | A broadcast constructs what's necessary to initiate and repeat messages
+--   for a given name.
+type Broadcast packing peerData body m =
+    MessageName -> m (Initiator packing peerData body m, WithRepeater packing peerData body m)
+
+-- | Initiate a broadcast of a given payload.
+type Initiator packing peerData body m = body -> SendActions packing peerData m -> m ()
+
+-- | Repeat the broadcast of a given payload.
+type Repeater m = m ()
+
+type WithRepeater packing peerData body m =
+     (Repeater m -> NodeId -> SendActions packing peerData m -> body -> m ())
+  -> Listener packing peerData m

--- a/src/Broadcast/Kademlia.hs
+++ b/src/Broadcast/Kademlia.hs
@@ -1,0 +1,279 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Broadcast.Kademlia (
+
+      kademliaBroadcast
+
+    ) where
+
+import           GHC.Generics (Generic)
+import           GHC.TypeLits (KnownNat)
+import           Control.Monad (forM)
+import           Control.Applicative ((<|>))
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Concurrent.STM.TVar as STM
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Network.Discovery.Abstract
+import           Network.Discovery.Transport.Kademlia
+import qualified Network.Kademlia as K
+import qualified Network.Kademlia.Instance as KI
+import qualified Network.Kademlia.Tree as KT
+import           Network.Kademlia.Types (toByteStruct, distance, ByteStruct, nodeId)
+import           Broadcast.Abstract
+import           Data.Binary
+import qualified Data.Set as S
+import qualified Data.Map.Strict as M
+import qualified Node as N
+import           Node.Message (Serializable, BinaryP)
+
+data WithKademliaIdentifier bytes body = WithKademliaIdentifier {
+      wkiIdentifier :: KIdentifier bytes
+    , wkiBody :: body
+    }
+
+deriving instance ( Show body ) => Show (WithKademliaIdentifier bytes body)
+
+instance ( KnownNat bytes, Binary body ) => Binary (WithKademliaIdentifier bytes body) where
+    put wki = do
+        put (wkiIdentifier wki)
+        put (wkiBody wki)
+    get = WithKademliaIdentifier <$> get <*> get
+
+kademliaBroadcast
+    :: forall bytes peerData body m .
+       ( KnownNat bytes, Binary body, MonadIO m )
+    => KademliaDiscovery bytes m
+    -> Broadcast BinaryP peerData body m
+kademliaBroadcast kd messageName = do
+    initiator <- pure $ kademliaInitiator kd messageName
+    withRepeater <- pure $ kademliaWithRepeater kd messageName
+    pure (initiator, withRepeater)
+
+kademliaInitiator
+    :: forall bytes peerData body m .
+       ( KnownNat bytes, Binary body, MonadIO m )
+    => KademliaDiscovery bytes m
+    -> N.MessageName
+    -> Initiator BinaryP peerData body m
+kademliaInitiator kd messageName body sactions = do
+    let payload = WithKademliaIdentifier myKId body
+    kademliaTree <- liftIO . STM.atomically . STM.readTVar . KI.sTree . KI.state . kdInstance $ kd
+    knownAddresses <- liftIO . STM.atomically . STM.readTVar . kdEndPointAddresses $ kd
+    -- We get the targets from the KademliaInstance, but we don't necessarily
+    -- have their EndPointAddress's! Those are kept by the Discovery layer.
+    -- It's possible that we're aware of a node (it's in a k-bucket on the
+    -- kademlia instance) but we're not (yet) aware of its EndPointAddress.
+    --
+    -- KT.toView doesn't give us quite what we want. Each element of the list
+    -- does not necessarily correspond to a distinct subtree, i.e. there could
+    -- be a list in 'targets' which contains more than one node that should be
+    -- contacted.
+    -- The size of these lists is bounded (referred to as k in the literature I
+    -- think, they're k-buckets) so...
+    --
+    -- TODO this is not quite right. Must choose precisely one node with
+    -- a given MostSignificant 1 bit.
+    --let buckets = KT.toView kademliaTree >>= organizeBucket . eliminateId myKId
+    let buckets = organizeBucket myKId . eliminateId myKId . KT.toList $ kademliaTree
+    liftIO . putStrLn $ "Initial broadcast buckets are " ++ show buckets
+    -- TODO concurrently.
+    _ <- forM buckets $ \knodes -> case firstKnownAddress knownAddresses knodes of
+        -- TODO we know a node but not yet its address. This isn't an
+        -- error and will probably happen once in a while. Log it?
+        Nothing -> do
+            liftIO . putStrLn $ "Missing addresses for " ++ show knodes
+        Just addr -> do
+            liftIO . putStrLn $ "Initiating broadcast to " ++ show addr
+            N.sendTo sactions (N.NodeId addr) messageName payload
+    pure ()
+    where
+    myKId = K.nodeId (K.node (kdInstance kd))
+
+kademliaWithRepeater
+    :: forall bytes peerData body m .
+       ( Binary body, KnownNat bytes, MonadIO m )
+    => KademliaDiscovery bytes m
+    -> N.MessageName
+    -> WithRepeater BinaryP peerData body m
+kademliaWithRepeater kd messageName f = N.ListenerActionOneMsg $ \nodeId sactions (wki :: WithKademliaIdentifier bytes body) -> do
+    let senderKId = wkiIdentifier wki
+    let body = wkiBody wki
+    let repeater = do
+            let payload = WithKademliaIdentifier myKId body
+            kademliaTree <- liftIO . STM.atomically . STM.readTVar . KI.sTree . KI.state . kdInstance $ kd
+            knownAddresses <- liftIO . STM.atomically . STM.readTVar . kdEndPointAddresses $ kd
+            let buckets = bucketsCloserTo myKId senderKId kademliaTree
+            liftIO . putStrLn $ "Repeat broadcast buckets are " ++ show buckets
+            --liftIO . putStrLn $ "My id is " ++ show (toByteStruct myKId)
+            --liftIO . putStrLn $ "His id is " ++ show (toByteStruct senderKId)
+            -- TODO concurrently.
+            _ <- forM buckets $ \knodes -> case firstKnownAddress knownAddresses knodes of
+                Nothing -> pure ()
+                Just addr -> N.sendTo sactions (N.NodeId addr) messageName payload
+            pure ()
+    f repeater nodeId sactions body
+    where
+    myKId = K.nodeId (K.node (kdInstance kd))
+
+firstKnownAddress :: Ord k => M.Map k v -> [k] -> Maybe v
+firstKnownAddress map lst = case lst of
+    [] -> Nothing
+    (x : xs) -> M.lookup x map <|> firstKnownAddress map xs
+
+eliminateId :: Eq k => k -> [Node k] -> [Node k]
+eliminateId k = filter ((/=) k . nodeId)
+
+bucketsCloserTo
+    :: forall bytes .
+       ( KnownNat bytes )
+    => KIdentifier bytes
+    -> KIdentifier bytes
+    -> KT.NodeTree (KIdentifier bytes)
+    -> [[K.Node (KIdentifier bytes)]]
+bucketsCloserTo here there tree@(KT.NodeTree _ _) =
+    buckets [trimBucket' bshere bsthere (KT.toList tree)]
+    --subtree bshere bsthere tree
+    where
+    -- Follow the NodeTree until a differing bit is found and give the tree
+    -- on the "here" side of the tree. That's a subtree where every element is
+    -- closer to "here" than to "there".
+    subtree
+        :: [Bool]
+        -> [Bool]
+        -> KT.NodeTreeElem (KIdentifier bytes)
+        -> [[Node (KIdentifier bytes)]]
+    -- Same bits: recurse.
+    subtree (True:bshere') (True:bsthere') (KT.Split _ right) = subtree bshere' bsthere' right
+    subtree (False:bshere') (False:bsthere') (KT.Split left _) = subtree bshere' bsthere' left
+    -- Different bits: take the one on the side of 'bshere' (right for 1 bit,
+    -- left for 0 bit).
+    subtree (True:bshere') (False:bsthere') (KT.Split _ right)  = buckets (KT.toView (KT.NodeTree bshere' right))
+    subtree (False:bshere') (True:bsthere') (KT.Split left _) = buckets (KT.toView (KT.NodeTree bshere' left))
+    -- Reached a bucket: we're not quite ready to return it. First, some
+    -- nodes in there must be eliminated depending upon 'bshere' and 'bsthere'.
+    --
+    subtree bshere' bsthere' (KT.Bucket ns) =
+        let trimmed :: [Node (KIdentifier bytes)]
+            trimmed = trimBucket bshere' bsthere' (fmap fst . fst $ ns)
+        in  buckets [trimmed]
+
+    -- Organize buckets according to most-significant 1 bit and eliminate any
+    -- node with the 'here' identifier.
+    buckets
+        :: [[Node (KIdentifier bytes)]]
+        -> [[Node (KIdentifier bytes)]]
+    buckets = flip (>>=) (organizeBucket here . eliminateId here . eliminateId there)
+
+    -- Eliminate nodes which are closer to the second [Bool] than to the
+    -- first [Bool].
+    trimBucket
+        :: [Bool]
+        -> [Bool]
+        -> [Node (KIdentifier bytes)]
+        -> [Node (KIdentifier bytes)]
+    trimBucket bshere bsthere = filter $ \node ->
+        let fromHere = zipWith xor (toByteStruct (nodeId node)) bshere
+            toThere = zipWith xor (toByteStruct (nodeId node)) bsthere
+        in  case fromHere `compare` toThere of
+                EQ -> False
+                LT -> True
+                GT -> False
+
+    xor :: Bool -> Bool -> Bool
+    xor a b = not (a && b) && (a || b)
+
+    trimBucket'
+        :: [Bool]
+        -> [Bool]
+        -> [Node (KIdentifier bytes)]
+        -> [Node (KIdentifier bytes)]
+    trimBucket' here there = filter $ \node -> go here there (toByteStruct (nodeId node))
+      where
+      go here there bs = case (here, there, bs) of
+          (True:here', True:there', True:bs') -> go here' there' bs'
+          (True:here', True:there', False:bs') -> False
+          (False:here', False:there', False:bs') -> go here' there' bs'
+          (False:here', False:there', True:bs') -> False
+          (True:here', False:there', False:bs') -> False
+          (True:here', False:there', True:bs') -> True
+          (False:here', True:there', False:bs') -> True
+          (False:here', True:there', True:bs') -> False
+          -- Both are equal.
+          ([], [], []) -> False
+
+    bshere :: [Bool]
+    bshere = toByteStruct here
+    bsthere :: [Bool]
+    bsthere = toByteStruct there
+
+
+-- This is not working right because the NodeTree isn't necessarily very tall.
+-- We need a way to take a bucket (a [Node i]) and give it the tree structure.
+--
+-- The most straightforward way I can see is to use the bit structure, though
+-- that's in practice going to be 160 elements and may be too slow.
+--
+-- Broadcast: for each thing in the bucket, we want to take its distance from
+-- the broadcaster, and then insert it into a map keyed on its most significant
+-- 1 bit. Then we just take the elements of this map. 
+
+newtype MostSignificant = MostSignificant {
+      getMostSignificant :: ByteStruct
+    }
+
+instance Eq MostSignificant where
+    MostSignificant left == MostSignificant right = msbEq left right
+
+instance Ord MostSignificant where
+    MostSignificant left `compare` MostSignificant right = msbCompare left right
+
+msbEq :: ByteStruct -> ByteStruct -> Bool
+msbEq (True:_) (True:_) = True
+msbEq (False:left) (False:right) = msbEq left right
+msbEq _ _ = False
+
+msbCompare :: ByteStruct -> ByteStruct -> Ordering
+msbCompare (True:_) (True:_) = EQ
+msbCompare (False:left) (False:right) = msbCompare left right
+msbCompare (False:_) (True:_) = LT
+msbCompare (True:_) (False:_) = GT
+
+-- | Organize a bucket into a list of buckets, where each list consists of
+--   nodes which have the same most-significant 1 bit.
+organizeBucket
+    :: forall bytes .
+       ( KnownNat bytes )
+    => KIdentifier bytes
+    -> [Node (KIdentifier bytes)]
+    -> [[Node (KIdentifier bytes)]]
+organizeBucket kId = M.elems . msbMap
+    where
+    msbMap :: [Node (KIdentifier bytes)] -> M.Map MostSignificant [Node (KIdentifier bytes)]
+    -- msbMap = flip foldr M.empty $ \node ->
+    --     M.alter (maybe (Just [node]) (Just . (:) node)) (MostSignificant (toByteStruct (nodeId node)))
+    msbMap = flip foldr M.empty $ \node ->
+        M.alter (maybe (Just [node]) (Just . (:) node)) (MostSignificant (nodeId node `distance` kId))
+
+    --referenceBits = toByteStruct kId
+
+{-
+-- The n'th element of the resulting list consists only of nodes whose identifier
+-- bit xor'd with the reference bit has most significant 1 bit at the n'th
+-- spot.
+organizeBucket'
+    :: forall bytes .
+       ( KnownNat bytes )
+    => KIdentifier bytes
+    -> [Node (KIdentifier bytes)]
+    -> [[Node (KIdentifier bytes)]]
+organizeBucket' kId nodes = go referenceBits nodes []
+    where
+    go _ [] acc = acc
+    go [] _ acc = error "organizeBucket' this case makes no sense"
+    go (bit:bits) nodes acc = 
+    referenceBits = toByteStruct kId
+    -}

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -1,11 +1,18 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 
 module Network.Discovery.Transport.Kademlia
        ( K.Node (..)
        , K.Peer (..)
        , KademliaDiscoveryErrorCode (..)
        , kademliaDiscovery
+       , KIdentifier (..)
+       , makeKIdentifier
+       , makeKIdentifierPaddedTrimmed
        , KSerialize(..)
        ) where
 
@@ -14,15 +21,78 @@ import qualified Control.Concurrent.STM.TVar as TVar
 import           Control.Monad               (forM)
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
 import           Data.Binary                 (Binary, decodeOrFail, encode)
+import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Lazy        as BL
 import qualified Data.Map.Strict             as M
 import qualified Data.Set                    as S
 import           Data.Typeable               (Typeable)
+import           Data.Word                   (Word8)
+import           Data.Proxy                  (Proxy(Proxy))
 import           GHC.Generics                (Generic)
+import           GHC.TypeLits                (Nat, KnownNat, natVal)
 import qualified Network.Kademlia            as K
-
 import           Network.Discovery.Abstract
 import           Network.Transport
+
+-- | A ByteString indexed by the number of bytes.
+--   Construct it using 'makeKIdentifier'.
+newtype KIdentifier (bytes :: Nat) = KIdentifier {
+      getKIdentifier :: BS.ByteString
+    }
+
+deriving instance Show (KIdentifier bytes)
+deriving instance Eq (KIdentifier bytes)
+deriving instance Ord (KIdentifier bytes)
+
+-- | Make a 'KIdentifier' from a 'ByteString'. It must be precisely 'bytes'
+--   bytes in length.
+makeKIdentifier
+    :: forall bytes .
+       ( KnownNat bytes )
+    => Proxy bytes
+    -> BS.ByteString
+    -> Either String (KIdentifier bytes)
+makeKIdentifier _ bs = case K.fromBS bs of
+    Left str -> Left str
+    Right (it, remainder) ->
+        if BS.null remainder
+        then Right it
+        else Left "KIdentifier is too long"
+
+-- | Make a 'KIdentifier' from a 'ByteString', handling too-short or too-long
+--   by respectively right-padding or right-trimming it.
+makeKIdentifierPaddedTrimmed
+    :: forall bytes .
+       ( KnownNat bytes )
+    => Proxy bytes
+    -> Word8
+    -> BS.ByteString
+    -> KIdentifier bytes
+makeKIdentifierPaddedTrimmed proxyBytes pad bs
+    | missingBytes == 0 =
+          let Right kid = makeKIdentifier proxyBytes bs in kid
+    | missingBytes < 0 =
+          let Right kid = makeKIdentifier proxyBytes (BS.take bytesVal bs) in kid
+    | missingBytes > 0 =
+          let Right kid = makeKIdentifier proxyBytes (BS.append bs (BS.pack (take missingBytes (repeat pad)))) in kid
+    | otherwise = error "makeKIdentifierPaddedTrimmed: impossible"
+    where
+    bytesVal :: Int
+    bytesVal = fromIntegral (natVal proxyBytes)
+    missingBytes = bytesVal - BS.length bs
+
+instance ( KnownNat bytes ) => K.Serialize (KIdentifier bytes) where
+    toBS (KIdentifier bs) = bs
+    fromBS bs = go ([], bs) (natVal (Proxy :: Proxy bytes))
+        where
+        go (words', remainder) n
+            | n < 0  = error "impossible: natVal is less than 0"
+            | n == 0 = Right (KIdentifier . BS.pack . reverse $ words', remainder)
+            | n > 0  = case BS.uncons remainder of
+                           Nothing -> Left "KIdentifier is too short"
+                           Just (word, remainder') ->
+                               go (word : words', remainder') (n - 1)
+            | otherwise = error "Serialize KIdentifier: impossible"
 
 -- | Wrapper which provides a 'K.Serialize' instance for any type with a
 --   'Binary' instance.
@@ -40,10 +110,10 @@ instance Binary i => K.Serialize (KSerialize i) where
 --   over the wire on request. NB there are two notions of ID here: the
 --   Kademlia IDs, and the 'EndPointAddress'es which are indexed by the former.
 kademliaDiscovery
-    :: forall m i .
-       (MonadIO m, Binary i, Ord i, Show i)
-    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-    -> K.Node i
+    :: forall m bytes .
+       (MonadIO m, KnownNat bytes)
+    => K.KademliaInstance (KIdentifier bytes) (KSerialize EndPointAddress)
+    -> K.Node (KIdentifier bytes)
     -- ^ A known peer, necessary in order to join the network.
     --   If there are no other peers in the network, use this node's id.
     -> EndPointAddress
@@ -53,7 +123,7 @@ kademliaDiscovery kademliaInst initialPeer myAddress = do
     -- The Kademlia identifier of the local node.
     let kid = K.nodeId (K.node kademliaInst)
     -- A TVar to cache the set of known peers at the last use of 'discoverPeers'
-    peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    peersTVar :: TVar.TVar (M.Map (K.Node (KIdentifier byyes)) EndPointAddress)
         <- liftIO . TVar.newTVarIO $ M.empty
     let knownPeers = fmap (S.fromList . M.elems) . liftIO . TVar.readTVarIO $ peersTVar
     let discoverPeers = liftIO $ kademliaDiscoverPeers kademliaInst peersTVar
@@ -70,14 +140,14 @@ kademliaDiscovery kademliaInst initialPeer myAddress = do
 -- | Join a Kademlia network (using a given known node address) and update the
 --   known peers cache.
 kademliaJoinAndUpdate
-    :: forall i .
-       ( Binary i, Ord i )
-    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
-    -> K.Node i
+    :: forall bytes .
+       ( KnownNat bytes )
+    => K.KademliaInstance (KIdentifier bytes) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KIdentifier bytes)) EndPointAddress)
+    -> K.Node (KIdentifier bytes)
     -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
 kademliaJoinAndUpdate kademliaInst peersTVar initialPeer = do
-    result <- K.joinNetwork kademliaInst initialPeer'
+    result <- K.joinNetwork kademliaInst initialPeer
     case result of
         K.NodeBanned -> pure $ Left (DiscoveryError KademliaNodeBanned "Node is banned by network")
         K.IDClash -> pure $ Left (DiscoveryError KademliaIdClash "ID clash in network")
@@ -89,20 +159,16 @@ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer = do
             endPointAddresses <- fmap (M.mapMaybe id) (kademliaLookupEndPointAddresses kademliaInst M.empty peerList)
             STM.atomically $ TVar.writeTVar peersTVar endPointAddresses
             pure $ Right (S.fromList (M.elems endPointAddresses))
-  where
-    initialPeer' :: K.Node (KSerialize i)
-    initialPeer' = case initialPeer of
-        K.Node peer nid -> K.Node peer (KSerialize nid)
 
 -- | Update the known peers cache.
 --
 --   FIXME: error reporting. Should perhaps give a list of all of the errors
 --   which occurred.
 kademliaDiscoverPeers
-    :: forall i .
-       ( Binary i, Ord i )
-    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-    -> TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
+    :: forall bytes .
+       ( KnownNat bytes )
+    => K.KademliaInstance (KIdentifier bytes) (KSerialize EndPointAddress)
+    -> TVar.TVar (M.Map (K.Node (KIdentifier bytes)) EndPointAddress)
     -> IO (Either (DiscoveryError KademliaDiscoveryErrorCode) (S.Set EndPointAddress))
 kademliaDiscoverPeers kademliaInst peersTVar = do
     recordedPeers <- TVar.readTVarIO peersTVar
@@ -118,16 +184,16 @@ kademliaDiscoverPeers kademliaInst peersTVar = do
 -- | Look up the 'EndPointAddress's for a set of nodes.
 --   See 'kademliaLookupEndPointAddress'
 kademliaLookupEndPointAddresses
-    :: forall i .
-       ( Binary i, Ord i )
-    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-    -> M.Map (K.Node (KSerialize i)) EndPointAddress
-    -> [K.Node (KSerialize i)]
-    -> IO (M.Map (K.Node (KSerialize i)) (Maybe EndPointAddress))
+    :: forall bytes .
+       ( KnownNat bytes )
+    => K.KademliaInstance (KIdentifier bytes) (KSerialize EndPointAddress)
+    -> M.Map (K.Node (KIdentifier bytes)) EndPointAddress
+    -> [K.Node (KIdentifier bytes)]
+    -> IO (M.Map (K.Node (KIdentifier bytes)) (Maybe EndPointAddress))
 kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers = do
     -- TODO do this in parallel, as each one may induce a blocking lookup.
     endPointAddresses <- forM currentPeers (kademliaLookupEndPointAddress kademliaInst recordedPeers)
-    let assoc :: [(K.Node (KSerialize i), Maybe EndPointAddress)]
+    let assoc :: [(K.Node (KIdentifier bytes), Maybe EndPointAddress)]
         assoc = zip currentPeers endPointAddresses
     pure $ M.fromList assoc
 
@@ -138,13 +204,13 @@ kademliaLookupEndPointAddresses kademliaInst recordedPeers currentPeers = do
 --   we look that up in the table. Nodes for which the 'EndPointAddress' is
 --   already known are not looked up.
 kademliaLookupEndPointAddress
-    :: forall i .
-       ( Binary i, Ord i )
-    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-    -> M.Map (K.Node (KSerialize i)) EndPointAddress
+    :: forall bytes .
+       ( KnownNat bytes )
+    => K.KademliaInstance (KIdentifier bytes) (KSerialize EndPointAddress)
+    -> M.Map (K.Node (KIdentifier bytes)) EndPointAddress
     -- ^ The current set of recorded peers. We don't lookup an 'EndPointAddress'
     --   for any of these, we just use the one in the map.
-    -> K.Node (KSerialize i)
+    -> K.Node (KIdentifier bytes)
     -> IO (Maybe EndPointAddress)
 kademliaLookupEndPointAddress kademliaInst recordedPeers peer@(K.Node _ nid) =
     case M.lookup peer recordedPeers of

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -4,9 +4,9 @@
 module Network.Discovery.Transport.Kademlia
        ( K.Node (..)
        , K.Peer (..)
-       , KademliaConfiguration (..)
        , KademliaDiscoveryErrorCode (..)
        , kademliaDiscovery
+       , KSerialize(..)
        ) where
 
 import qualified Control.Concurrent.STM      as STM
@@ -18,7 +18,6 @@ import qualified Data.ByteString.Lazy        as BL
 import qualified Data.Map.Strict             as M
 import qualified Data.Set                    as S
 import           Data.Typeable               (Typeable)
-import           Data.Word                   (Word16)
 import           GHC.Generics                (Generic)
 import qualified Network.Kademlia            as K
 
@@ -36,49 +35,33 @@ instance Binary i => K.Serialize (KSerialize i) where
         Right (unconsumed, _, i) -> Right (KSerialize i, BL.toStrict unconsumed)
     toBS (KSerialize i) = BL.toStrict . encode $ i
 
--- | Configuration for a Kademlia node.
-data KademliaConfiguration i = KademliaConfiguration {
-      kademliaPort :: Word16
-      -- ^ The port on which to run the server (it's UDP)
-    , kademliaId   :: i
-      -- ^ Some value to use as the identifier for this node. To use it, it must
-      --   have a 'Binary' instance. You may want to take a random value, and
-      --   it should serialize to something long enough for your expected
-      --   network size (every node in the network needs a unique id).
-    }
-
 -- | Discovery peers using the Kademlia DHT. Nodes in this network will store
 --   their (assumed to be TCP transport) 'EndPointAddress'es and send them
 --   over the wire on request. NB there are two notions of ID here: the
 --   Kademlia IDs, and the 'EndPointAddress'es which are indexed by the former.
---
---   Many side-effects here: a Kademlia instance is created, grabbing a UDP
---   socket and using it to talk to a peer, storing data in the DHT once it has
---   been joined.
 kademliaDiscovery
     :: forall m i .
        (MonadIO m, Binary i, Ord i, Show i)
-    => KademliaConfiguration i
+    => K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
     -> K.Node i
     -- ^ A known peer, necessary in order to join the network.
     --   If there are no other peers in the network, use this node's id.
     -> EndPointAddress
     -- ^ Local endpoint address. Will store it in the DHT.
     -> m (NetworkDiscovery KademliaDiscoveryErrorCode m)
-kademliaDiscovery configuration initialPeer myAddress = do
-    let kid :: KSerialize i
-        kid = KSerialize (kademliaId configuration)
-    let port :: Int
-        port = fromIntegral (kademliaPort configuration)
-    -- A Kademlia instance to do the DHT magic.
-    kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-        <- liftIO $ K.create port kid
+kademliaDiscovery kademliaInst initialPeer myAddress = do
+    -- The Kademlia identifier of the local node.
+    let kid = K.nodeId (K.node kademliaInst)
     -- A TVar to cache the set of known peers at the last use of 'discoverPeers'
     peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
         <- liftIO . TVar.newTVarIO $ M.empty
     let knownPeers = fmap (S.fromList . M.elems) . liftIO . TVar.readTVarIO $ peersTVar
     let discoverPeers = liftIO $ kademliaDiscoverPeers kademliaInst peersTVar
-    let close = liftIO $ K.close kademliaInst
+    -- Nothing to do on close. It's not our responsibility to close the
+    -- KademliaInstance.
+    -- TBD perhaps we should flip a bit here so that knownPeers and
+    -- discoverPeers no longer work after 'close'?
+    let close = pure ()
     -- Join the network and store the local 'EndPointAddress'.
     _ <- liftIO $ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer
     liftIO $ K.store kademliaInst kid (KSerialize myAddress)
@@ -99,7 +82,6 @@ kademliaJoinAndUpdate kademliaInst peersTVar initialPeer = do
         K.NodeBanned -> pure $ Left (DiscoveryError KademliaNodeBanned "Node is banned by network")
         K.IDClash -> pure $ Left (DiscoveryError KademliaIdClash "ID clash in network")
         K.NodeDown -> pure $ Left (DiscoveryError KademliaInitialPeerDown "Initial peer is down")
-        -- [sic]
         K.JoinSuccess -> do
             peerList <- K.dumpPeers kademliaInst
             -- We have the peers, but we do not have the 'EndPointAddress'es for

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
   - '.'
   - location:
       git: https://github.com/serokell/kademlia.git
-      commit: 278171b8ab104c78aa95bcdd9b63c8ced4fb1ed2
+      commit: 21df94f41008f82ee023e8e0324c7e4a82c4fef2
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,9 +2,9 @@ resolver: lts-8.2
 
 packages:
   - '.'
-  - location:
-      git: https://github.com/serokell/kademlia.git
-      commit: 21df94f41008f82ee023e8e0324c7e4a82c4fef2
+  - location: '../kademlia'
+      # git: https://github.com/serokell/kademlia.git
+      # commit: 21df94f41008f82ee023e8e0324c7e4a82c4fef2
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport


### PR DESCRIPTION
By using Kademlia's network overlay, we can broadcast to the network without flooding (explanation below).

`examples/Broadcast.hs` demonstrates that it works. I have run it for 80 nodes locally, 20 broadcasts, and it's consistent (every node receives every message).

Please give comments on the interface for broadcasting. I'm not so happy with it but it's a good start I think.

## Broadcasting using Kademlia's overlay

Every node in the network is a Kademlia peer, and so has an `n`-bit identifier (typical case is `n = 160`). These identifiers give the network a tree structure with every node as a leaf. Find its position by interpreting a `1` bit as "go left" and a `0` bit as "go right" so that each `n`-bit identifier gives a path of length `n` from root to leaf.

When a node wishes to *initiate* a broadcast, it sends the message to one peer from each *bucket* (definition later) that it's aware of, and it adds to the data payload its own identifier. When a node wishes to *repeat* a broadcast that it heard from some other peer, it uses that peer identifier which it received with the data, along with its own identifier, to determine which nodes to repeat the message to, such that they certainly have not already been contacted. It sends the same payload to them, but with its own identifier instead of the sender's.

What are these buckets? Every node is a leaf in Kademlia's routing tree, so imagine walking back up that path from node to root. At each level, there's a subtree which contains the node, and another subtree which does not. The latter subtree is what I call a bucket. The broadcast initiator sends the message to one node from each of these buckets. Those nodes, if they wish to repeat the broadcast, will send the message to one node from each of *their* buckets, restricted to those nodes which are closer to them than to the sender, i.e. they are, from the sender's point of view, within the same bucket as the receiver.

See section 4.3.2 of [this paper](http://www.hiradastechnika.hu/data/upload/file/2009/2009%20I/Pages_from_HT0901a_2.pdf).