### PR TITLE
Preliminary example of delaying network input

### DIFF
--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -24,7 +24,7 @@ import           Mockable.Production
 import           Network.Discovery.Abstract
 import qualified Network.Discovery.Transport.Kademlia as K
 import           Network.Transport.Abstract           (Transport (..))
-import           Network.Transport.Concrete           (concrete)
+import           Network.Transport.Concrete.TCP       (concreteTCP)
 import qualified Network.Transport.TCP                as TCP
 import           Node
 import           System.Environment                   (getArgs)
@@ -102,8 +102,9 @@ main = runProduction $ do
 
     when (number > 99 || number < 1) $ error "Give a number in [1,99]"
 
-    Right transport_ <- liftIO $ TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
-    let transport = concrete transport_
+    Right tcpTransport <-
+        liftIO $ TCP.createTransportExposeInternals ("127.0.0.1") ("10128") TCP.defaultTCPParameters
+    let transport = concreteTCP runProduction tcpTransport
 
     liftIO . putStrLn $ "Spawning " ++ show number ++ " nodes"
     nodeThreads <- forM [0..number] (makeNode transport)

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -16,7 +16,7 @@ import           GHC.Generics               (Generic)
 import           Message.Message            (BinaryP (..))
 import           Mockable.Concurrent        (delay, for, fork, killThread)
 import           Mockable.Production
-import           Network.Transport.Concrete (concrete)
+import           Network.Transport.Concrete.TCP (concreteTCP)
 import qualified Network.Transport.TCP      as TCP
 import           Node
 import           System.Random
@@ -71,8 +71,9 @@ listeners anId = [pongWorker]
 main :: IO ()
 main = runProduction $ do
 
-    Right transport_ <- liftIO $ TCP.createTransport ("127.0.0.1") ("10128") TCP.defaultTCPParameters
-    let transport = concrete transport_
+    Right tcpTransport <-
+        liftIO $ TCP.createTransportExposeInternals ("127.0.0.1") ("10128") TCP.defaultTCPParameters
+    let transport = concreteTCP runProduction tcpTransport
 
     let prng1 = mkStdGen 0
     let prng2 = mkStdGen 1

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -16,6 +16,7 @@ Library
                         Network.Discovery.Transport.Kademlia
                         Network.Transport.Abstract
                         Network.Transport.Concrete
+                        Network.Transport.Concrete.TCP
 
                         Node
 
@@ -63,6 +64,7 @@ Library
                       , network
                       , network-transport
                       , network-transport-inmemory
+                      , network-transport-tcp
                       , mtl >= 2.2.1
                       , random
                       , universum

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -29,6 +29,8 @@ import           Mockable.Exception       (Bracket (..), Catch (..), Throw (..))
 import           Mockable.SharedAtomic    (SharedAtomic (..), SharedAtomicT)
 import           Universum                (MonadFail (..))
 
+import Debug.Trace
+
 newtype Production t = Production
     { runProduction :: IO t
     } deriving (Functor, Applicative, Monad)
@@ -63,6 +65,7 @@ type instance Promise Production = Conc.Async
 
 instance Mockable Async Production where
     liftMockable (Async m)          = Production $ Conc.async (runProduction m)
+    liftMockable (Link promise)     = Production $ Conc.link promise
     liftMockable (Wait promise)     = Production $ Conc.wait promise
     liftMockable (WaitAny promises) = Production $ Conc.waitAny promises
     liftMockable (Cancel promise)   = Production $ Conc.cancel promise

--- a/src/Network/Transport/Concrete/TCP.hs
+++ b/src/Network/Transport/Concrete/TCP.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Network.Transport.Concrete.TCP
+    ( concreteTCP
+    ) where
+
+import           Control.Monad.IO.Class (MonadIO)
+import           Network.Transport.Abstract
+import           Network.Transport.Concrete (concrete)
+import qualified Network.Transport     as NT
+import qualified Network.Transport.TCP as TCP
+
+-- | Use a TCP transport and its internals to create an abstract
+--   Transport over any MonadIO m which also has an arrow back into IO.
+concreteTCP
+    :: forall m .
+       ( MonadIO m )
+    => (forall t . m t -> IO t)
+    -> (NT.Transport, TCP.TransportInternals)
+    -> Transport m
+concreteTCP lowerIO (transport, internals) = concrete newEndPoint closeTransport
+    where
+    newEndPoint :: Policy m -> IO (Either (TransportError NewEndPointErrorCode) NT.EndPoint)
+    newEndPoint policy = TCP.newEndPointInternal internals tcpPolicy
+        where
+        tcpPolicy = lowerPolicy lowerIO policy
+    closeTransport :: IO ()
+    closeTransport = NT.closeTransport transport
+
+lowerPolicy :: (forall t . m t -> IO t) -> Policy m -> TCP.Policy
+lowerPolicy lowerIO tcpPolicy addr = lowerPolicyDecision lowerIO (tcpPolicy addr)
+
+lowerPolicyDecision
+    :: (forall t . m t -> IO t)
+    -> PolicyDecision m
+    -> TCP.PolicyDecision
+lowerPolicyDecision lowerIO (PolicyDecision pdecision) = TCP.PolicyDecision $ do
+    (decision, next) <- lowerIO pdecision
+    let continue = lowerPolicyDecision lowerIO next
+    pure $ case decision of
+        Accept -> (TCP.Accept, continue)
+        Block until -> (TCP.Block (lowerIO until), continue)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -236,7 +236,7 @@ node
     :: forall packing m t .
        ( Mockable Fork m, Mockable Throw m, Mockable Channel m
        , Mockable SharedAtomic m, Mockable Bracket m, Mockable Catch m
-       , Mockable Async m
+       , Mockable Async m, Mockable Delay m
        , MonadFix m
        , Serializable packing MessageName
        )

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,10 @@ packages:
       git: https://github.com/serokell/universum
       commit: db3cd301545e5da000e53ca2cdf274e0386192bf
     extra-dep: true
+  - location:
+      git: https://github.com/avieth/network-transport-tcp
+      commit: e03e2abade9211d22ed00d0de563d3904c439521
+    extra-dep: true
 
 extra-deps:
   - network-transport-inmemory-0.5.2


### PR DESCRIPTION
This is just a demo of my progress towards being able to selectively delay input from a given peer.

It requires a patch to network-transport-tcp, as shown in the diff of `stack.yaml`. That has complicated the use of a concrete network-transport, because the patch only applies to network-transport-tcp, not to every network-transport. How or if this feature would be included in network-transport is up for debate.

Hard-coded into `Node.Internal` is a policy which delays every socket read from every peer by 5 milliseconds. To make a useful backpressure feature we'll allow the programmer to specify how to compute such a delay for each peer from a set of statistics.