### PR TITLE
Backpressure

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -10,7 +10,6 @@ import           Control.Monad              (unless)
 
 import           Data.Time.Units            (Second)
 import           GHC.IO.Encoding            (setLocaleEncoding, utf8)
-import qualified Network.Transport.TCP      as TCP
 import           Options.Applicative.Simple (simpleOptions)
 import           Serokell.Util.Concurrent   (threadDelay)
 import           System.Random              (mkStdGen)
@@ -20,7 +19,8 @@ import           Mockable                   (Production (runProduction))
 
 import           Bench.Network.Commons      (MeasureEvent (..), Ping (..), Pong (..),
                                              loadLogConfig, logMeasure)
-import           Network.Transport.Concrete (concrete)
+import qualified Network.Transport.TCP      as TCP
+import qualified Network.Transport.Concrete.TCP as TCP
 import           Node                       (ListenerAction (..), NodeAction (..), node,
                                              sendTo)
 import           Node.Message               (BinaryP (..))
@@ -39,9 +39,9 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" "127.0.0.1" (show port)
+    Right transport_ <- TCP.createTransportExposeInternals "0.0.0.0" "127.0.0.1" (show port)
         TCP.defaultTCPParameters
-    let transport = concrete transport_
+    let transport = TCP.concrete (runProduction . usingLoggerName "receiver") transport_
 
     let prng = mkStdGen 0
 

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -15,7 +15,8 @@ import           Data.Time.Units            (Microsecond, fromMicroseconds)
 import           GHC.Generics               (Generic)
 import           Mockable.Concurrent        (delay, fork, killThread)
 import           Mockable.Production
-import           Network.Transport.Concrete (concrete)
+import           Network.Transport.Abstract (closeTransport)
+import           Network.Transport.Concrete.TCP as TCP (concrete)
 import qualified Network.Transport.TCP      as TCP
 import           Node
 import           Node.Message               (BinaryP (..))
@@ -71,8 +72,9 @@ listeners anId = [pongWorker]
 main :: IO ()
 main = runProduction $ do
 
-    Right transport_ <- liftIO $ TCP.createTransport "0.0.0.0" "127.0.0.1" "10128" TCP.defaultTCPParameters
-    let transport = concrete transport_
+    Right transport_ <- liftIO $
+        TCP.createTransportExposeInternals "0.0.0.0" "127.0.0.1" "10128" TCP.defaultTCPParameters
+    let transport = TCP.concrete runProduction transport_
 
     let prng1 = mkStdGen 0
     let prng2 = mkStdGen 1
@@ -92,3 +94,4 @@ main = runProduction $ do
         killThread tid2
         liftIO . putStrLn $ "Stopping nodes"
     liftIO . putStrLn $ "All done."
+    closeTransport transport

--- a/examples/abuse/Main.hs
+++ b/examples/abuse/Main.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Control.Monad (unless)
+import           GHC.Generics (Generic)
+import           Control.Monad.IO.Class (liftIO)
+import           Data.String (fromString)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.Binary (Binary)
+import           Network.Transport.Abstract
+import           Network.Transport.Concrete
+import qualified Network.Transport.TCP as TCP
+import qualified Network.Transport.Concrete.TCP as TCP
+import           Node
+import           Node.Message
+import           System.Environment (getArgs)
+import           System.Random (mkStdGen)
+import           Data.Time.Units
+import           Mockable.Concurrent (delay, async, wait, cancel)
+import           Mockable.SharedAtomic
+import qualified Mockable.Metrics as Metrics
+import           Mockable.Production
+import qualified System.Remote.Monitoring as Monitoring
+import qualified System.Metrics as Monitoring
+import qualified System.Metrics.Distribution as Monitoring.Distribution
+
+-- |
+-- = Abuse demonstration number 1.
+--
+-- The client will ping some server as fast as possible with rather large
+-- payloads (circa 16 megabytes).
+--
+-- The client will handle these with single-message listeners that delay for
+-- 5 seconds and then update the total number of bytes received so far.
+--
+-- The 5 second delay isn't really necessary. as the dispatcher always tries
+-- to start parsing the message immediately. However the delay does somewhat
+-- simulate a real world situation, where the data is not discarded right
+-- away.
+--
+-- |
+-- = Single-message listeners
+--
+-- For a single-message listener, the node's handler will try to parse it all
+-- and then hand it off to the application's handler. This just makes perfect
+-- sense: the single-message handler surely wants to know about the whole
+-- message. However, this means that the application's handler really doesn't
+-- get a say in backpressure. The node's handler will always try to churn
+-- through the message as fast as possible, without regard for how efficiently
+-- the application's handlers are dealing with it. Imposing some backpressure
+-- here could be done by a mutable queueing policy as a function of some
+-- dispatcher statistics. For example, if there are an extermely high number of
+-- handlers running, we could shrink the input buffer bounds until that
+-- number subsides.
+--
+-- |
+-- = Ingress buffer size versus thread pool
+--
+-- Another option is a thread pool. If we limit the number of handlers which
+-- can run at a given time, then eventually we'll stop reading input because the
+-- pool is full, and if the ingress buffer is bounded then there's a limit at
+-- which the client will feel the pressure.
+--
+-- On the other hand, suppose we set the ingress buffer size to 0. This means
+-- we won't take any more input. It essentially limits the thread pool to the
+-- number of currently running threads. 
+--
+-- In either case, we need bounds on the ingress buffer. But these bounds are
+-- enough to impose a bound on a thread pool, so it's not necessary to
+-- explicitly pool any threads!
+--
+-- |
+-- = Conversation listeners
+--
+-- These listeners are given a 'recv' function which, with the backpressure
+-- implementation, directly corresponds to reading from the socket to the peer.
+-- These listeners *do* have a say in backpressure. The node's handler will
+-- only parse the message name, and leave it to the application's handler to
+-- determine when to pull in more data. If a client spams a conversation
+-- listener, and that listener doesn't read fast enough, the client will
+-- eventually slow down as its TCP egress buffers fill up.
+
+data Ping = Ping ByteString
+deriving instance Generic Ping
+instance Binary Ping
+instance Message Ping where
+    messageName _ = fromString "Ping"
+    formatMessage _ = fromString "Ping"
+
+-- ~16mb
+payloadSize :: Integral a => a
+payloadSize = 2^24
+
+payload :: ByteString
+payload = fromString (take payloadSize (repeat '0'))
+
+main :: IO ()
+main = do
+
+    choice : rest <- getArgs
+
+    case choice of
+        "server" -> case rest of
+            [serverPort] -> runProduction $ server serverPort
+            _ -> error "Second argument for a server must be a port"
+        "client" -> case rest of
+            [serverPort, clientPort] -> runProduction $ client serverPort clientPort
+            _ -> error "Arguments for a client must be the server port followed by client port"
+        _ -> error "First argument must be server or client"
+
+setupMonitor :: Node Production -> Production Monitoring.Server
+setupMonitor node = do
+    store <- liftIO Monitoring.newStore
+    liftIO $ flip (Monitoring.registerGauge "Remotely-initated handlers") store $ runProduction $ do
+        stats <- nodeStatistics node
+        Metrics.readGauge (stRunningHandlersRemote stats)
+    liftIO $ flip (Monitoring.registerGauge "Locally-initated handlers") store $ runProduction $ do
+        stats <- nodeStatistics node
+        Metrics.readGauge (stRunningHandlersLocal stats)
+    liftIO $ flip (Monitoring.registerDistribution "Handler elapsed time (normal)") store $ runProduction $ do
+        stats <- nodeStatistics node
+        liftIO $ Monitoring.Distribution.read (stHandlersFinishedNormally stats)
+    liftIO $ flip (Monitoring.registerDistribution "Handler elapsed time (exceptional)") store $ runProduction $ do
+        stats <- nodeStatistics node
+        liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
+    liftIO $ Monitoring.registerGcMetrics store
+    server <- liftIO $ Monitoring.forkServerWith store "127.0.0.1" 8000
+    liftIO $ putStrLn "Forked EKG server on port 8000"
+    return server
+
+server :: String -> Production ()
+server port = do
+
+    Right (transport_, internals) <-
+        liftIO $ TCP.createTransportExposeInternals "0.0.0.0" "127.0.0.1" port TCP.defaultTCPParameters
+    let transport = TCP.concrete runProduction (transport_, internals)
+    --let transport = concrete transport_
+    let prng = mkStdGen 0
+    totalBytes <- newSharedAtomic 0
+
+    liftIO . putStrLn $ "Starting server on port " ++ show port
+
+    node transport prng BinaryP $ \node -> do
+        -- Set up the EKG monitor.
+        setupMonitor node
+        pure $ NodeAction [listener totalBytes] $ \saction -> do
+            -- Just wait for user interrupt
+            liftIO . putStrLn $ "Server running. Press any key to stop."
+            liftIO getChar
+
+    closeTransport transport
+
+    total <- modifySharedAtomic totalBytes $ \bs -> return (bs, bs)
+
+    liftIO . putStrLn $ "Server processed " ++ show total ++ " bytes"
+
+    where
+
+    -- The server listener just forces the whole bytestring then discards.
+    listener :: SharedAtomicT Production Integer -> ListenerAction BinaryP Production
+    listener totalBytes = ListenerActionOneMsg $ \peer sactions (Ping body) -> do
+        -- Retain the body for a few seconds.
+        delay (5000000 :: Microsecond)
+        let len = BS.length body
+        modifySharedAtomic totalBytes $ \total ->
+            let !newTotal = fromIntegral len + total
+            in  return (newTotal, ())
+        --liftIO . putStrLn $ "Server heard message of length " ++ show (BS.length body)
+
+client :: String -> String -> Production ()
+client serverPort clientPort = do
+
+    Right (transport_, internals) <-
+        liftIO $ TCP.createTransportExposeInternals "0.0.0.0" "127.0.0.1" clientPort TCP.defaultTCPParameters
+    let transport = TCP.concrete runProduction (transport_, internals)
+    --let transport = concrete transport_
+    let prng = mkStdGen 1
+    -- Assume the server's end point identifier is 0. It always will be.
+    let serverAddress = NodeId (TCP.encodeEndPointAddress "127.0.0.1" serverPort 0)
+
+    liftIO . putStrLn $ "Starting client on port " ++ show clientPort
+
+    totalBytes <- node transport prng BinaryP $ \node ->
+        pure $ NodeAction [] $ \saction -> do
+            -- Track total bytes sent, and a bool indicating whether we should
+            -- stop, so that we don't have to resort to cancelling the threads
+            -- (which may leave some bytes missing from the total).
+            totalBytes <- newSharedAtomic (0, False)
+            -- 4 threads will spam.
+            spammer1 <- async $ spamServer serverAddress totalBytes saction
+            spammer2 <- async $ spamServer serverAddress totalBytes saction
+            spammer3 <- async $ spamServer serverAddress totalBytes saction
+            spammer4 <- async $ spamServer serverAddress totalBytes saction
+            liftIO . putStrLn $ "Client is spamming the server. Press any key to stop."
+            liftIO getChar
+            -- Signal the threads to not try another send.
+            -- They'll eventually stop.
+            _ <- modifySharedAtomic totalBytes $ \(bs, _) -> return ((bs, True), ())
+            wait spammer1
+            wait spammer2
+            wait spammer3
+            wait spammer4
+            modifySharedAtomic totalBytes $ \total -> return (total, total)
+            
+    closeTransport transport
+
+    liftIO . putStrLn $ "Client sent " ++ show totalBytes ++ " bytes"
+
+spamServer :: NodeId -> SharedAtomicT Production (Integer, Bool) -> SendActions BinaryP Production -> Production ()
+spamServer server totalBytes sactions = do
+    sendTo sactions server (Ping payload)
+    stop <- modifySharedAtomic totalBytes $ \(total, stop) ->
+        let !newTotal = total + payloadSize
+        in  return ((newTotal, stop), stop)
+    unless stop (spamServer server totalBytes sactions)

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -33,6 +33,7 @@ Library
                         Mockable.SharedAtomic
                         Mockable.SharedExclusive
                         Mockable.BoundedQueue
+                        Mockable.Metrics
 
                         Node.Internal
                         Node.Message
@@ -79,6 +80,8 @@ Library
                       , transformers
                       , unordered-containers
                       , semigroups
+                      , ekg-core
+                      , ekg
 
   hs-source-dirs:       src
   default-language:     Haskell2010

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -32,7 +32,6 @@ Library
                         Mockable.Production
                         Mockable.SharedAtomic
                         Mockable.SharedExclusive
-                        Mockable.BoundedQueue
                         Mockable.Metrics
 
                         Node.Internal

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -16,6 +16,8 @@ Library
                         Network.Discovery.Transport.Kademlia
                         Network.Transport.Abstract
                         Network.Transport.Concrete
+                        Network.Transport.Concrete.TCP
+                        Network.Transport.ConnectionBuffers
 
                         Node
 
@@ -29,6 +31,8 @@ Library
                         Mockable.Monad
                         Mockable.Production
                         Mockable.SharedAtomic
+                        Mockable.SharedExclusive
+                        Mockable.BoundedQueue
 
                         Node.Internal
                         Node.Message
@@ -62,6 +66,7 @@ Library
                       , network
                       , network-transport
                       , network-transport-inmemory
+                      , network-transport-tcp
                       , mtl >= 2.2.1
                       , random
                       , universum

--- a/src/Mockable/Instances.hs
+++ b/src/Mockable/Instances.hs
@@ -18,6 +18,9 @@ import           Mockable.Channel           (ChannelT)
 import           Mockable.Class             (MFunctor' (..), Mockable (..))
 import           Mockable.Concurrent        (Promise, ThreadId)
 import           Mockable.SharedAtomic      (SharedAtomicT)
+import           Mockable.SharedExclusive   (SharedExclusiveT)
+import           Mockable.Metrics
+import           Network.Transport.ConnectionBuffers (BufferT)
 
 instance (Mockable d m, MFunctor' d (ReaderT r m) m) => Mockable d (ReaderT r m) where
     liftMockable dmt = ReaderT $ \r -> liftMockable $ hoist' (flip runReaderT r) dmt
@@ -38,9 +41,20 @@ instance ( Mockable d m
 type instance ThreadId (LoggerNameBox m) = ThreadId m
 type instance Promise (LoggerNameBox m) = Promise m
 type instance SharedAtomicT (LoggerNameBox m) = SharedAtomicT m
+type instance SharedExclusiveT (LoggerNameBox m) = SharedExclusiveT m
 type instance ChannelT (LoggerNameBox m) = ChannelT m
+type instance Gauge (LoggerNameBox m) = Gauge m
+type instance Counter (LoggerNameBox m) = Counter m
+type instance Distribution (LoggerNameBox m) = Distribution m
+type instance BufferT (LoggerNameBox m) = BufferT m
 
+type instance BufferT (ReaderT r m) = BufferT m
 type instance ThreadId (ReaderT r m) = ThreadId m
 type instance Promise (ReaderT r m) = Promise m
 type instance SharedAtomicT (ReaderT r m) = SharedAtomicT m
+type instance SharedExclusiveT (ReaderT r m) = SharedExclusiveT m
 type instance ChannelT (ReaderT r m) = ChannelT m
+type instance Gauge (ReaderT r m) = Gauge m
+type instance Counter (ReaderT r m) = Counter m
+type instance Distribution (ReaderT r m) = Distribution m
+type instance BufferT (ReaderT r m) = BufferT m

--- a/src/Mockable/Metrics.hs
+++ b/src/Mockable/Metrics.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Mockable.Metrics (
 
@@ -60,6 +62,28 @@ data Metrics (m :: * -> *) (t :: *) where
     NewDistribution :: Metrics m (Distribution m)
     AddSample :: Distribution m -> Double -> Metrics m ()
     ReadDistribution :: Distribution m -> Metrics m Stats
+
+instance
+    ( Gauge m ~ Gauge n
+    , Counter m ~ Counter n
+    , Distribution m ~ Distribution n
+    ) => MFunctor' Metrics m n
+    where
+    hoist' _ term = case term of
+
+        NewGauge -> NewGauge
+        IncGauge gauge -> IncGauge gauge
+        DecGauge gauge -> DecGauge gauge
+        SetGauge gauge n -> SetGauge gauge n
+        ReadGauge gauge -> ReadGauge gauge
+
+        NewCounter -> NewCounter
+        IncCounter counter -> IncCounter counter
+        ReadCounter counter -> ReadCounter counter
+
+        NewDistribution -> NewDistribution
+        AddSample distr s -> AddSample distr s
+        ReadDistribution distr -> ReadDistribution distr
 
 newGauge :: ( Mockable Metrics m ) => m (Gauge m)
 newGauge = liftMockable NewGauge

--- a/src/Mockable/Metrics.hs
+++ b/src/Mockable/Metrics.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Mockable.Metrics (
+
+      Gauge
+    , Counter
+    , Distribution
+    , Metrics(..)
+    , Stats(..)
+
+    , newGauge
+    , incGauge
+    , decGauge
+    , setGauge
+    , readGauge
+
+    , newCounter
+    , incCounter
+    , readCounter
+
+    , newDistribution
+    , addSample
+    , readDistribution
+
+    ) where
+
+import Data.Int (Int64)
+import Mockable.Class
+
+type family Gauge (m :: * -> *) :: *
+type family Counter (m :: * -> *) :: *
+type family Distribution (m :: * -> *) :: *
+
+-- | Various statistics.
+data Stats = Stats {
+      mean :: Double
+    , variance :: Double
+    , count :: Int64
+    , sum :: Double
+    , min :: Double
+    , max :: Double
+    }
+
+-- | Counters, gauages, and distributions.
+data Metrics (m :: * -> *) (t :: *) where
+
+    NewGauge :: Metrics m (Gauge m)
+    IncGauge :: Gauge m -> Metrics m ()
+    DecGauge :: Gauge m -> Metrics m ()
+    SetGauge :: Gauge m -> Int64 -> Metrics m ()
+    ReadGauge :: Gauge m -> Metrics m Int64
+
+    NewCounter :: Metrics m (Counter m)
+    IncCounter :: Counter m -> Metrics m ()
+    ReadCounter :: Counter m -> Metrics m Int64
+
+    NewDistribution :: Metrics m (Distribution m)
+    AddSample :: Distribution m -> Double -> Metrics m ()
+    ReadDistribution :: Distribution m -> Metrics m Stats
+
+newGauge :: ( Mockable Metrics m ) => m (Gauge m)
+newGauge = liftMockable NewGauge
+
+incGauge :: ( Mockable Metrics m ) => Gauge m -> m ()
+incGauge = liftMockable . IncGauge
+
+decGauge :: ( Mockable Metrics m ) => Gauge m -> m ()
+decGauge = liftMockable . DecGauge
+
+setGauge :: ( Mockable Metrics m ) => Gauge m -> Int64 -> m ()
+setGauge gauge = liftMockable . SetGauge gauge
+
+readGauge :: ( Mockable Metrics m ) => Gauge m -> m Int64
+readGauge = liftMockable . ReadGauge
+
+newCounter :: ( Mockable Metrics m ) => m (Counter m)
+newCounter = liftMockable NewCounter
+
+incCounter :: ( Mockable Metrics m ) => Counter m -> m ()
+incCounter = liftMockable . IncCounter
+
+readCounter :: ( Mockable Metrics m ) => Counter m -> m Int64
+readCounter = liftMockable . ReadCounter
+
+newDistribution :: ( Mockable Metrics m ) => m (Distribution m)
+newDistribution = liftMockable NewDistribution
+
+addSample :: ( Mockable Metrics m ) => Distribution m -> Double -> m ()
+addSample distr = liftMockable . AddSample distr
+
+readDistribution :: ( Mockable Metrics m ) => Distribution m -> m Stats
+readDistribution = liftMockable . ReadDistribution

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -29,7 +29,6 @@ import           Mockable.CurrentTime     (CurrentTime (..), realTime)
 import           Mockable.Exception       (Bracket (..), Catch (..), Throw (..))
 import           Mockable.SharedAtomic    (SharedAtomic (..), SharedAtomicT)
 import           Mockable.SharedExclusive (SharedExclusive (..), SharedExclusiveT)
-import           Mockable.BoundedQueue
 import qualified Mockable.Metrics         as Metrics
 import qualified System.Metrics.Distribution as EKG.Distribution
 import qualified System.Metrics.Gauge     as EKG.Gauge

--- a/src/Mockable/SharedAtomic.hs
+++ b/src/Mockable/SharedAtomic.hs
@@ -12,6 +12,7 @@ module Mockable.SharedAtomic (
     , newSharedAtomic
     , readSharedAtomic
     , modifySharedAtomic
+    , withSharedAtomic
 
     ) where
 
@@ -39,3 +40,12 @@ modifySharedAtomic
     -> (s -> m (s, t))
     -> m t
 modifySharedAtomic sat f = liftMockable $ ModifySharedAtomic sat f
+
+withSharedAtomic
+    :: ( Mockable SharedAtomic m )
+    => SharedAtomicT m s
+    -> (s -> m t)
+    -> m t
+withSharedAtomic sat f = liftMockable $ ModifySharedAtomic sat g
+    where
+    g s = fmap ((,) s) (f s)

--- a/src/Mockable/SharedExclusive.hs
+++ b/src/Mockable/SharedExclusive.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+module Mockable.SharedExclusive (
+
+      SharedExclusiveT
+    , SharedExclusive(..)
+    , newSharedExclusive
+    , putSharedExclusive
+    , takeSharedExclusive
+    , modifySharedExclusive
+    , readSharedExclusive
+
+    ) where
+
+import           Mockable.Class (MFunctor' (hoist'), Mockable (liftMockable))
+
+type family SharedExclusiveT (m :: * -> *) :: * -> *
+
+data SharedExclusive (m :: * -> *) (t :: *) where
+    NewSharedExclusive :: SharedExclusive m (SharedExclusiveT m t)
+    PutSharedExclusive :: SharedExclusiveT m t -> t -> SharedExclusive m ()
+    TakeSharedExclusive :: SharedExclusiveT m t -> SharedExclusive m t
+    ModifySharedExclusive :: SharedExclusiveT m t -> (t -> m (t, r)) -> SharedExclusive m r
+
+instance (SharedExclusiveT n ~ SharedExclusiveT m) => MFunctor' SharedExclusive m n where
+    hoist' _ NewSharedExclusive = NewSharedExclusive
+    hoist' _ (PutSharedExclusive var t) = PutSharedExclusive var t
+    hoist' _ (TakeSharedExclusive var) = TakeSharedExclusive var
+    hoist' nat (ModifySharedExclusive var f) = ModifySharedExclusive var (nat . f)
+
+newSharedExclusive :: ( Mockable SharedExclusive m ) => m (SharedExclusiveT m t)
+newSharedExclusive = liftMockable $ NewSharedExclusive
+
+putSharedExclusive :: ( Mockable SharedExclusive m ) => SharedExclusiveT m t -> t -> m ()
+putSharedExclusive var t = liftMockable $ PutSharedExclusive var t
+
+takeSharedExclusive :: ( Mockable SharedExclusive m ) => SharedExclusiveT m t -> m t
+takeSharedExclusive var = liftMockable $ TakeSharedExclusive var
+
+modifySharedExclusive :: ( Mockable SharedExclusive m ) => SharedExclusiveT m t -> (t -> m (t, r)) -> m r
+modifySharedExclusive var f = liftMockable $ ModifySharedExclusive var f
+
+readSharedExclusive :: ( Mockable SharedExclusive m ) => SharedExclusiveT m t -> m t
+readSharedExclusive var = liftMockable $ ModifySharedExclusive var (\t -> return (t, t))

--- a/src/Network/Transport/Concrete.hs
+++ b/src/Network/Transport/Concrete.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.Transport.Concrete
        ( concrete
+       , concreteEvent
+       , concreteEndPoint
        ) where
 
 import           Control.Monad.IO.Class     (MonadIO, liftIO)
@@ -11,24 +14,40 @@ import           Network.Transport.Abstract
 
 -- | Use a concrete network-transport within the abstract framework,
 --   specializing it to some MonadIO.
-concrete :: MonadIO m => NT.Transport -> Transport m
-concrete transport = Transport {
-      newEndPoint = concreteNewEndPoint (NT.newEndPoint transport)
+--   You also have to give a special variant of 'newEndPoint' which takes a
+--   'QDisc m t'.
+concrete
+    :: ( MonadIO m )
+    => (forall t . m t -> IO t)
+    -> NT.Transport
+    -> (forall t . NT.Transport -> QDisc IO t -> IO (Either (NT.TransportError NT.NewEndPointErrorCode) (EndPoint IO t)))
+    -> Transport m
+concrete lowerIO transport ntNewEndPoint = Transport {
+      newEndPoint = concreteNewEndPoint . ntNewEndPoint transport . concreteQDisc lowerIO
     , closeTransport = liftIO $ NT.closeTransport transport
+    }
+
+concreteQDisc
+    :: (forall t . m t -> IO t)
+    -> QDisc m t
+    -> QDisc IO t
+concreteQDisc lowerIO qdisc = QDisc {
+      qdiscEnqueue = lowerIO . qdiscEnqueue qdisc
+    , qdiscDequeue = lowerIO $ qdiscDequeue qdisc
     }
 
 concreteNewEndPoint
     :: ( MonadIO m )
-    => IO (Either (TransportError NewEndPointErrorCode) NT.EndPoint)
-    -> m (Either (TransportError NewEndPointErrorCode) (EndPoint m))
+    => IO (Either (TransportError NewEndPointErrorCode) (EndPoint IO t))
+    -> m (Either (TransportError NewEndPointErrorCode) (EndPoint m t))
 concreteNewEndPoint ntNewEndPoint = (fmap . fmap) concreteEndPoint (liftIO ntNewEndPoint)
 
-concreteEndPoint :: ( MonadIO m ) => NT.EndPoint -> EndPoint m
+concreteEndPoint :: ( MonadIO m ) => EndPoint IO t -> EndPoint m t
 concreteEndPoint ep = EndPoint {
-      receive = fmap concreteEvent (liftIO $ NT.receive ep)
-    , address = NT.address ep
-    , connect = concreteConnect (NT.connect ep)
-    , closeEndPoint = liftIO $ NT.closeEndPoint ep
+      receive = liftIO $ receive ep
+    , address = address ep
+    , connect = concreteConnect (connect ep)
+    , closeEndPoint = liftIO $ closeEndPoint ep
     }
 
 concreteEvent :: NT.Event -> Event
@@ -37,19 +56,19 @@ concreteEvent ev = case ev of
     NT.ConnectionClosed eid -> ConnectionClosed eid
     NT.ConnectionOpened eid reliability address -> ConnectionOpened eid reliability address
     NT.EndPointClosed -> EndPointClosed
-    NT.ErrorEvent (TransportError err str) -> ErrorEvent (TransportError (EventErrorCode err) str)
+    NT.ErrorEvent (TransportError err str) -> ErrorEvent (TransportError (EventError err) str)
     _ -> ErrorEvent (TransportError UnsupportedEvent "Unsupported event")
 
 concreteConnect
     :: ( MonadIO m )
-    => (EndPointAddress -> Reliability -> ConnectHints -> IO (Either (TransportError ConnectErrorCode) NT.Connection))
+    => (EndPointAddress -> Reliability -> ConnectHints -> IO (Either (TransportError ConnectErrorCode) (Connection IO)))
     -> (EndPointAddress -> Reliability -> ConnectHints -> m (Either (TransportError ConnectErrorCode) (Connection m)))
 concreteConnect ntConnect endPointAddress reliability hints = do
     choice <- liftIO $ ntConnect endPointAddress reliability hints
     pure (fmap concreteConnection choice)
 
-concreteConnection :: ( MonadIO m ) => NT.Connection -> Connection m
+concreteConnection :: ( MonadIO m ) => Connection IO -> Connection m
 concreteConnection ntConnection = Connection {
-      send = liftIO . NT.send ntConnection
-    , close = liftIO $ NT.close ntConnection
+      send = liftIO . send ntConnection
+    , close = liftIO $ close ntConnection
     }

--- a/src/Network/Transport/Concrete/TCP.hs
+++ b/src/Network/Transport/Concrete/TCP.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Network.Transport.Concrete.TCP (
+
+      concrete
+
+    ) where
+
+import Control.Monad.IO.Class (MonadIO)
+import Network.Transport.Abstract
+import qualified Network.Transport.Concrete as C
+import qualified Network.Transport as NT
+import qualified Network.Transport.TCP as TCP
+
+-- | Use a TCP transport and its internals to make a transport.
+--   The internals are necessary because they can accept a QDisc, but the
+--   network-transport API does not.
+concrete
+    :: ( MonadIO m )
+    => (forall t . m t -> IO t)
+    -> (NT.Transport, TCP.TransportInternals)
+    -> Transport m
+concrete lowerIO (transport, internals) = C.concrete lowerIO transport ntNewEndPoint
+    where
+    ntNewEndPoint _ qdisc = do
+        choice <- TCP.newEndPointInternal internals (concreteTCPQDisc qdisc)
+        case choice of
+            Left err -> return (Left err)
+            Right tcpEndPoint -> return (Right (concreteTCPEndPoint tcpEndPoint))
+
+concreteTCPEndPoint
+    :: ( )
+    => TCP.TCPEndPoint t
+    -> EndPoint IO t
+concreteTCPEndPoint tcpEndPoint = EndPoint {
+      receive = TCP.tcpReceive tcpEndPoint
+    , address = TCP.tcpAddress tcpEndPoint
+    , connect = \addr reliability hints -> do
+          outcome <- TCP.tcpConnect tcpEndPoint addr reliability hints
+          return $ fmap concreteTCPConnection outcome
+    , closeEndPoint = TCP.tcpCloseEndPoint tcpEndPoint
+    }
+
+concreteTCPConnection
+    :: ( )
+    => NT.Connection
+    -> Connection IO
+concreteTCPConnection conn = Connection {
+      send = NT.send conn
+    , close = NT.close conn
+    }
+
+concreteTCPQDisc
+    :: ( )
+    => QDisc IO t
+    -> TCP.QDisc t
+concreteTCPQDisc qdisc = TCP.QDisc {
+      TCP.qdiscEnqueue = qdiscEnqueue qdisc . C.concreteEvent
+    , TCP.qdiscDequeue = qdiscDequeue qdisc
+    }

--- a/src/Network/Transport/ConnectionBuffers.hs
+++ b/src/Network/Transport/ConnectionBuffers.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -58,6 +60,16 @@ data Buffer (m :: * -> *) (t :: *) where
     --   must maintain that writes are not possible when size >= bound, and
     --   size > bound is entirely possible.
     BoundBuffer :: BufferT m t -> (Int -> Int) -> Buffer m ()
+
+instance
+    ( BufferT m ~ BufferT n
+    ) => MFunctor' Buffer m n
+    where
+    hoist' _ term = case term of
+        NewBuffer i -> NewBuffer i
+        ReadBuffer buffer k -> ReadBuffer buffer k
+        WriteBuffer buffer t -> WriteBuffer buffer t
+        BoundBuffer buffer b -> BoundBuffer buffer b
 
 newBuffer :: ( Mockable Buffer m ) => Int -> m (BufferT m t)
 newBuffer bound = liftMockable $ NewBuffer bound

--- a/src/Network/Transport/ConnectionBuffers.hs
+++ b/src/Network/Transport/ConnectionBuffers.hs
@@ -1,0 +1,270 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Network.Transport.ConnectionBuffers (
+
+      connectionBufferQDisc
+    , Buffer(..)
+    , BufferT
+    , writeBuffer
+    , readBuffer
+    , readBuffer_
+    , recvAtMost
+    , ConnectionBuffersParams(..)
+    , ConnectionEvent(..)
+    , EndPointEvent(..)
+    , EndPointBuffer
+    , ConnectionBuffer
+    , InternalError(..)
+
+    ) where
+
+import Control.Monad (forM_, unless)
+import Control.Monad.IO.Class
+import Network.Transport.Abstract
+import qualified Data.Binary.Get as Bin
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as M
+-- TODO use NonEmptySet instead.
+import qualified Data.Set as S
+import Control.Exception
+import Control.Concurrent.STM
+import Control.Concurrent.STM.TBQueue
+import Mockable.Class
+import Mockable.SharedAtomic
+import Data.Typeable
+
+-- This connection-buffers QDisc needs an implementation of a bounded fifo
+-- buffer such that the head can be inspected and modified.
+
+type family BufferT (m :: * -> *) :: * -> *
+
+data Buffer (m :: * -> *) (t :: *) where
+    NewBuffer :: Int -> Buffer m (BufferT m t)
+    -- | Read from the head of the buffer, with the option to replace the
+    --   front with some other value. Useful in case you want to parse from
+    --   a buffer and you have leftover data.
+    ReadBuffer :: BufferT m t -> (t -> (Maybe t, r)) -> Buffer m r
+    WriteBuffer :: BufferT m t -> t -> Buffer m ()
+
+newBuffer :: ( Mockable Buffer m ) => Int -> m (BufferT m t)
+newBuffer bound = liftMockable $ NewBuffer bound
+
+writeBuffer :: ( Mockable Buffer m ) => BufferT m t -> t -> m ()
+writeBuffer buffer t = liftMockable $ WriteBuffer buffer t
+
+readBuffer :: ( Mockable Buffer m ) => BufferT m t -> (t -> (Maybe t, r)) -> m r
+readBuffer buffer f = liftMockable $ ReadBuffer buffer f
+
+readBuffer_ :: ( Mockable Buffer m ) => BufferT m t -> m t
+readBuffer_ buffer = liftMockable $ ReadBuffer buffer (\t -> (Nothing, t))
+
+-- | Try to decode a binary thing from a buffer. Any leftovers will be replaced.
+--   Closed and Lost are always replaced.
+decodeFromBuffer
+    :: ( Mockable Buffer m )
+    => Bin.Get t
+    -> BufferT m ConnectionEvent
+    -> m (Maybe t)
+decodeFromBuffer get buffer = case Bin.runGetIncremental get of
+    Bin.Partial continue -> go continue
+    Bin.Done _ _ a -> return (Just a)
+    Bin.Fail _ _ _ -> return Nothing
+    where
+
+    -- Repeatedly read from the buffer and continue the parse.
+    -- Leftover data is replaced when Done or Fail is encountered.
+    go continue = do
+        outcome <- readBuffer buffer $ \ev -> case ev of
+            Closed -> (Just Closed, Nothing)
+            Lost -> (Just Lost, Nothing)
+            Data bs -> case continue (Just (BL.toStrict bs)) of
+                Bin.Done trailing _ a -> (leftover trailing, Just (Right a))
+                Bin.Fail trailing _ _ -> (leftover trailing, Nothing)
+                Bin.Partial continue -> (Nothing, Just (Left continue))
+        case outcome of
+            Nothing -> return Nothing
+            Just (Left continue') -> go continue'
+            Just (Right t) -> return (Just t)
+
+    leftover bs = if BS.null bs then Nothing else Just (Data (BL.fromStrict bs))
+
+data ConnectionEvent = Data BL.ByteString | Closed | Lost
+
+data EndPointEvent m =
+    PeerOpenedConnection !ConnectionId !Reliability !EndPointAddress !(ConnectionBuffer m)
+  | LocalEndPointClosed
+  | LocalEndPointFailed
+  | LocalTransportFailed
+
+type EndPointBuffer m = BufferT m (EndPointEvent m)
+
+newEndPointBuffer :: ( Mockable Buffer m ) => Int -> m (EndPointBuffer m)
+newEndPointBuffer = newBuffer
+
+type ConnectionBuffer m = BufferT m ConnectionEvent
+
+newConnectionBuffer :: ( Mockable Buffer m ) => Int -> m (ConnectionBuffer m)
+newConnectionBuffer = newBuffer
+
+-- | Receive at most n bytes from a connection buffer. If the head of the
+--   buffer has more data than you asked for, the trailing data remains at
+--   the head of the buffer. Otherwise, the first event is removed.
+--   This will not block on a full queue, only on an empty one.
+recvAtMost :: ( Mockable Buffer m ) => Int -> ConnectionBuffer m -> m ConnectionEvent
+recvAtMost bytes cbuffer = readBuffer cbuffer $ \event -> case event of
+    Lost -> (Nothing, Lost)
+    Closed -> (Nothing, Closed)
+    Data lbs -> do
+        let (now, later) = BL.splitAt (fromIntegral bytes) lbs
+        if BL.null later
+        then (Nothing, Data now)
+        else (Just (Data later), Data now)
+
+-- | State that will be held internally by a connection-buffer QDisc and
+--   updated when events are enqueued.
+data ConnectionBuffersState m = ConnectionBuffersState {
+    qdiscBuffers :: !(M.Map ConnectionId (EndPointAddress, ConnectionBuffer m))
+  , qdiscConnections :: !(M.Map EndPointAddress (S.Set ConnectionId))
+  }
+
+-- | Parameters for a connection-buffer QDisc.
+data ConnectionBuffersParams m = ConnectionBuffersParams {
+    qdiscEventBufferSize :: Int
+  , qdiscConnectionBufferSize :: Int
+  , qdiscConnectionDataSize :: Int
+  , qdiscInternalError :: forall t . InternalError -> m t
+  }
+
+-- | A QDisc with a fixed bound for the size of the event queue and also for
+--   the size of the buffers for each connection.
+connectionBufferQDisc
+  :: forall m .
+     ( Mockable SharedAtomic m, Mockable Buffer m )
+  => ConnectionBuffersParams m
+  -> m (QDisc m (EndPointEvent m))
+connectionBufferQDisc qdiscParams = do
+
+  let endPointBound = qdiscEventBufferSize qdiscParams
+  let connectionBound = qdiscConnectionBufferSize qdiscParams
+  let maxChunkSize = fromIntegral (qdiscConnectionDataSize qdiscParams)
+  let internalError :: forall t . InternalError -> m t
+      internalError = qdiscInternalError qdiscParams
+
+  endPointBuffer <- newEndPointBuffer endPointBound
+  let dequeue :: m (EndPointEvent m)
+      dequeue = readBuffer_ endPointBuffer
+
+  qdiscState :: SharedAtomicT m (ConnectionBuffersState m)
+      <- newSharedAtomic (ConnectionBuffersState M.empty M.empty)
+
+  let writeBufferRespectingChunkSize :: ConnectionBuffer m -> BL.ByteString -> m ()
+      writeBufferRespectingChunkSize cbuffer lbs = do
+        let (now, later) = BL.splitAt maxChunkSize lbs
+        writeBuffer cbuffer (Data now)
+        unless (BL.null later) (writeBufferRespectingChunkSize cbuffer later)
+
+  let enqueue :: Event -> m ()
+      enqueue event = case event of
+
+        ConnectionOpened connid reliability addr -> do
+          connectionBuffer :: ConnectionBuffer m <- newConnectionBuffer connectionBound
+          () <- modifySharedAtomic qdiscState $ \st ->
+            case M.lookup connid (qdiscBuffers st) of
+              Nothing ->
+                let alteration :: Maybe (S.Set ConnectionId) -> S.Set ConnectionId
+                    alteration = maybe (S.singleton connid) (S.insert connid)
+                    st' = st {
+                        qdiscBuffers = M.insert connid (addr, connectionBuffer) (qdiscBuffers st)
+                      , qdiscConnections = M.alter (Just . alteration) addr (qdiscConnections st)
+                      }
+                in  return (st', ())
+              _ -> internalError DuplicateConnection
+          let event = PeerOpenedConnection connid reliability addr connectionBuffer
+          writeBuffer endPointBuffer event
+
+        -- Events on a particular connection buffer will be consistent with
+        -- their nt-tcp delivery because 'enqueue' will not be called
+        -- concurrently for two events with the same 'ConnectionId'.
+
+        ConnectionClosed connid -> do
+          buffer <- modifySharedAtomic qdiscState $ \st ->
+            case M.lookup connid (qdiscBuffers st) of
+              Nothing -> internalError UnknownConnectionClosed
+              Just (addr, buffer) ->
+                let updateIt set = if S.null set' then Nothing else Just set'
+                      where
+                      set' = S.delete connid set
+                    st' = st {
+                        qdiscBuffers = M.delete connid (qdiscBuffers st)
+                      , qdiscConnections = M.update updateIt addr (qdiscConnections st)
+                      }
+                in  return (st', buffer)
+          writeBuffer buffer Closed
+
+        Received connid bytes -> do
+          buffer <- withSharedAtomic qdiscState $ \st ->
+            case M.lookup connid (qdiscBuffers st) of
+              Nothing -> internalError UnknownConnectionReceived
+              Just (_, buffer) -> return buffer
+          -- Will block if the buffer is full, ultimately blocking the thread
+          -- which is reading from the socket.
+          writeBufferRespectingChunkSize buffer (BL.fromChunks bytes)
+
+        EndPointClosed ->
+          let event = LocalEndPointClosed
+          in  writeBuffer endPointBuffer event
+
+        ErrorEvent (TransportError (EventError EventEndPointFailed) _) ->
+          let event = LocalEndPointFailed
+          in  writeBuffer endPointBuffer event
+
+        ErrorEvent (TransportError (EventError EventTransportFailed) _) ->
+          let event = LocalTransportFailed
+          in  writeBuffer endPointBuffer event
+
+        -- Must find all connections for that address and write 'Lost' to their
+        -- buffers.
+        ErrorEvent (TransportError (EventError (EventConnectionLost addr)) _) -> do
+          buffers <- modifySharedAtomic qdiscState $ \st ->
+            case M.lookup addr (qdiscConnections st) of
+              -- TBD: will network-transport report all of the connections to
+              -- this peer as closed, before giving the connection lost
+              -- message? I think so but I'm not sure.
+              Nothing -> return (st, [])
+              -- Get the buffers for all of the ConnectionIds and remove them
+              -- from the state.
+              -- connids is guaranteed non-empty set but GHC doesn't know that.
+              Just connids ->
+                let combine connid (buffers, deletedBuffers) =
+                      case M.updateLookupWithKey (const (const Nothing)) connid buffers of
+                        -- updateLookupWithKey returns the deleted value if it
+                        -- was deleted.
+                        (Just (_, buffer), buffers') -> (buffers', Just buffer : deletedBuffers)
+                        _ -> (buffers, Nothing : deletedBuffers)
+                    (buffers, deletedBuffers) = foldr combine (qdiscBuffers st, []) (S.toList connids)
+                    st' = st {
+                        qdiscBuffers = buffers
+                      , qdiscConnections = M.delete addr (qdiscConnections st)
+                      }
+                in  return (st', deletedBuffers)
+          forM_ buffers $ maybe (internalError InconsistentConnectionState) (flip writeBuffer Lost)
+
+  return $ QDisc enqueue dequeue
+
+data InternalError =
+    InconsistentConnectionState
+  | UnknownConnectionClosed
+  | UnknownConnectionLost
+  | UnknownConnectionReceived
+  | DuplicateConnection
+  deriving (Typeable, Show)
+
+instance Exception InternalError

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -52,6 +52,8 @@ import           Mockable.Concurrent
 import           Mockable.Exception
 import           Mockable.SharedAtomic
 import           Mockable.SharedExclusive
+import           Mockable.CurrentTime
+import qualified Mockable.Metrics           as Metrics
 import qualified Network.Transport.ConnectionBuffers as CB
 import qualified Network.Transport.Abstract as NT
 import           Node.Internal              (ChannelIn, ChannelOut)
@@ -64,7 +66,7 @@ import           System.Wlog                (WithLogger, logError, logDebug)
 data Node m = forall event . Node {
       nodeId         :: LL.NodeId
     , nodeEndPoint   :: NT.EndPoint m event
-    , nodeStatistics :: m LL.Statistics
+    , nodeStatistics :: m (LL.Statistics m)
     }
 
 nodeEndPointAddress :: Node m -> NT.EndPointAddress
@@ -165,6 +167,7 @@ nodeSendActions
        ( Mockable CB.Buffer m, Mockable Throw m, Mockable Catch m
        , Mockable Bracket m, Mockable SharedAtomic m, Mockable SharedExclusive m
        , Mockable Async m, Ord (Promise m ())
+       , Mockable CurrentTime m, Mockable Metrics.Metrics m
        , WithLogger m, MonadFix m
        , Packable packing MessageName )
     => LL.Node m
@@ -246,6 +249,7 @@ node
        , Mockable SharedAtomic m, Mockable Bracket m, Mockable Catch m
        , Mockable Async m, Mockable Concurrently m, Ord (Promise m ())
        , Mockable SharedExclusive m
+       , Mockable CurrentTime m, Mockable Metrics.Metrics m
        , MonadFix m, Serializable packing MessageName, WithLogger m
        )
     => NT.Transport m

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -457,19 +457,6 @@ stRemoveHandler provenance elapsed outcome statistics = case provenance of
             avg' = avg - (1 / fromIntegral npeers)
             avg2' = avg - (fromIntegral (2 * nhandlers + 1) / fromIntegral npeers) 
 
--- |
--- = Statistics and monitoring
---
--- It will be useful to track statistics about a node, for instance the
--- number of handlers induced by a given peer. A way to monitor these would be
--- nice as well. EKG comes to mind, and it looks like the 'Distribution' type
--- from this package will be very useful. However, it's not obvious that it
--- can do what we want. We must track the number of handlers per-peer, and also
--- the total number of peers and the total number of handlers. These are all
--- integral, suitable for gauges.
---
-
-
 -- | Bring up a 'Node' using a network transport.
 startNode :: ( Mockable SharedAtomic m, Mockable Bracket m
              , Mockable Buffer m, Mockable Throw m, Mockable Catch m

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,8 +15,8 @@ packages:
       commit: db3cd301545e5da000e53ca2cdf274e0386192bf
     extra-dep: true
   - location:
-      git: https://github.com/serokell/network-transport-tcp.git
-      commit: 586c9bf830252476522cab6274ef8ddc32615686
+      git: https://github.com/avieth/network-transport-tcp
+      commit: b9892b2be4cae3ca5f3720c6e0fc0ae458119700
     extra-dep: true
 
 extra-deps:


### PR DESCRIPTION
The current implementation of our node has a single dispatcher thread, pulling network-transport `Event`s from an unbounded `Chan` and then determining what to do with them, typically putting received data into some other unbounded `Chan`. That's no good. network-transport-tcp will pull data from sockets as fast as it can, no matter what.

Even with queueing and buffering for network-transport-tcp as in https://github.com/haskell-distributed/network-transport-tcp/pull/46 we're still not quite there. We could define some `QDisc` which bounds the input buffers for each socket, but we're still left with only one means of output: `receive :: EndPoint -> Event`. It aggregates events from *every* socket, and then our dispatcher still hands out the data to the unbounded `Chan`s of the handlers.

So I've made a somewhat radical change to network-transport-tcp which you can find here: https://github.com/avieth/network-transport-tcp/tree/avieth/backpressure . It allows for the `QDisc` to give out a custom type, not necessarily `Event`. This makes the `ConnectionBuffers :: QDisc EndPointEvent` possible (see `src/Network/Transport/ConnectionBuffers.hs`). This puts out an event for every peer connection which includes a bounded input buffer for that connection alone. The main dispatcher thread of our node can spin as fast as it wants, picking up new connections and handing off their input buffers to handlers. Those handlers will be responsible for reading from the buffers. A full buffer leads to a slowdown on the peer's side, hence we have very natural, somewhat automatic backpressure: if your handler is slow, it'll slow the input from the peer.

Also included in this patch is some statistics-gathering in `Node.Internal`. Although they're currently not used to inform a backpressure policy, they *are* used in the abuse example to feed an EKG server. You can run that example and then view live statistics by opening `localhost:8000`:

```
./examples/abuse/Main server 7777 +RTS -N1 -T -RTS
# Now open the EKG console at localhost:8000 and view the flat graphs.
./examples/abuse/Main client 7777 7778 +RTS -N -RTS
# Watch the graphs in the EKG console as the server is spammed with data
```