### PR TITLE
Improved abuse and backpressure demonstration

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -47,7 +47,7 @@ main = do
 
     runProduction $ usingLoggerName "receiver" $ do
         node transport prng BinaryP () $ \_ ->
-            pure $ NodeAction [pingListener noPong] $ \_ -> do
+            NodeAction [pingListener noPong] $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where
     pingListener noPong =

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -76,7 +76,7 @@ main = do
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
             node transport prngNode BinaryP () $ \node' ->
-                pure $ NodeAction [pongListener] $ \sactions -> do
+                NodeAction [pongListener] $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)
                     delay (fromIntegral duration :: Second)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -60,7 +60,7 @@ worker anId generator discovery = pingWorker generator
             peerSet <- knownPeers discovery
             liftIO . putStrLn $ show anId ++ " has peer set: " ++ show peerSet
             forM_ (S.toList peerSet) $ \addr -> withConnectionTo sendActions (NodeId addr) $
-                \(cactions :: ConversationActions BS.ByteString Void Pong Production) -> do
+                \peerData (cactions :: ConversationActions Void Pong Production) -> do
                     received <- recv cactions
                     case received of
                         Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show addr
@@ -71,7 +71,7 @@ listeners :: NodeId -> [Listener Packing BS.ByteString Production]
 listeners anId = [pongListener]
     where
     pongListener :: ListenerAction Packing BS.ByteString Production
-    pongListener = ListenerActionConversation $ \peerData peerId (cactions :: ConversationActions BS.ByteString Pong Void Production) -> do
+    pongListener = ListenerActionConversation $ \peerData peerId (cactions :: ConversationActions Pong Void Production) -> do
         liftIO . putStrLn $ show anId ++  " heard PING from " ++ show peerId ++ " with peer data " ++ B8.unpack peerData
         send cactions Pong
 

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -92,8 +92,8 @@ makeNode transport i = do
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    fork $ node transport prng1 BinaryP (B8.pack "my peer data!") $ \node' -> do
-        pure $ NodeAction (listeners . nodeId $ node') $ \sactions -> do
+    fork $ node transport prng1 BinaryP (B8.pack "my peer data!") $ \node' ->
+        NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
             discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node')
             worker (nodeId node') prng2 discovery sactions `finally` closeDiscovery discovery

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
@@ -85,12 +88,12 @@ main = runProduction $ do
     let prng4 = mkStdGen 3
 
     liftIO . putStrLn $ "Starting nodes"
-    node transport prng1 BinaryP (B8.pack "I am node 1") $ \node1 -> do
-        setupMonitor 8000 runProduction node1
-        pure $ NodeAction (listeners . nodeId $ node1) $ \sactions1 ->
-            node transport prng2 BinaryP (B8.pack "I am node 2") $ \node2 -> do
-                setupMonitor 8001 runProduction node2
-                pure $ NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
+    node transport prng1 BinaryP (B8.pack "I am node 1") $ \node1 ->
+        NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
+            setupMonitor 8000 runProduction node1
+            node transport prng2 BinaryP (B8.pack "I am node 2") $ \node2 ->
+                NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
+                    setupMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1
                     tid2 <- fork $ worker (nodeId node2) prng4 [nodeId node1] sactions2
                     liftIO . putStrLn $ "Hit return to stop"

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -56,8 +56,8 @@ worker anId generator peerIds = pingWorker generator
             let (i, gen') = randomR (0,1000000) g
                 us = fromMicroseconds i :: Microsecond
             delay us
-            let pong :: NodeId -> ConversationActions BS.ByteString Ping Pong Production -> Production ()
-                pong peerId cactions = do
+            let pong :: NodeId -> Production BS.ByteString -> ConversationActions Ping Pong Production -> Production ()
+                pong peerId peerData cactions = do
                     liftIO . putStrLn $ show anId ++ " sent PING to " ++ show peerId
                     received <- recv cactions
                     case received of
@@ -70,7 +70,7 @@ listeners :: NodeId -> [Listener Packing BS.ByteString Production]
 listeners anId = [pongListener]
     where
     pongListener :: ListenerAction Packing BS.ByteString Production
-    pongListener = ListenerActionConversation $ \peerData peerId (cactions :: ConversationActions BS.ByteString Pong Ping Production) -> do
+    pongListener = ListenerActionConversation $ \peerData peerId (cactions :: ConversationActions Pong Ping Production) -> do
         liftIO . putStrLn $ show anId ++  " heard PING from " ++ show peerId ++ " with peer data " ++ B8.unpack peerData
         send cactions Pong
         liftIO . putStrLn $ show anId ++ " sent PONG to " ++ show peerId

--- a/examples/abuse/Main.hs
+++ b/examples/abuse/Main.hs
@@ -91,8 +91,8 @@ server port qdiscChoice = do
 
     node transport prng BinaryP () $ \node -> do
         -- Set up the EKG monitor.
-        setupMonitor 8000 runProduction node
-        pure $ NodeAction [listener totalBytes] $ \saction -> do
+        NodeAction [listener totalBytes] $ \saction -> do
+            setupMonitor 8000 runProduction node
             -- Just wait for user interrupt
             liftIO . putStrLn $ "Server running. Press any key to stop."
             liftIO getChar
@@ -129,7 +129,7 @@ client serverPort clientPort = do
     liftIO . putStrLn $ "Starting client on port " ++ show clientPort
 
     totalBytes <- node transport prng BinaryP () $ \node ->
-        pure $ NodeAction [] $ \saction -> do
+        NodeAction [] $ \saction -> do
             -- Track total bytes sent, and a bool indicating whether we should
             -- stop, so that we don't have to resort to cancelling the threads
             -- (which may leave some bytes missing from the total).

--- a/examples/abuse/README.md
+++ b/examples/abuse/README.md
@@ -1,0 +1,97 @@
+# Backpressure and peer abuse example
+
+## Overview
+
+network-transport-tcp, as it's implemented in master and all releases, uses
+an unbounded queue to gather data from its peers. For each socket, a thread will
+read data from it, determine the appropriate network-transport `Event`, put
+that `Event` into the unbounded queue, and then continue reading. These `Event`s
+will come out of the queue when `receive :: EndPoint -> IO Event` is used.
+Consequently, there is no relationship between the rate at which the receiver
+processes these events (via `receive`) and the rate at which they are generated
+by incoming data from peers. In fact, there's no way at all to control the rate
+of incoming data; the program will always take it in as fast as possible,
+because an unbounded queue can always take more data. 
+That's to say, this system lacks *backpressure*: congestion at a server does
+not eventually induce congestion at its client.
+
+A proposed and accepted [change to network-transport-tcp](https://github.com/haskell-distributed/network-transport-tcp/pull/46)
+allows for the user to specify a different queueing strategy. Perhaps the
+simplest alternative to the unbounded queueing present in master is to swap
+the `Chan Event` for an `MVar Event`, conceptually replacing an unbounded
+queue with a bounded, single-place queue. Both of these strategies, known as
+`QDisc`s (queueing disciplines) are included in that pull request, and they're
+simple enough to repeat here:
+
+```Haskell
+simpleUnboundedQDisc :: IO (QDisc t)
+simpleUnboundedQDisc = do
+  unboundedQueue <- newChan
+  return $ QDisc {
+      qdiscDequeue = readChan unboundedQueue
+    , qdiscEnqueue = \_ _ t -> writeChan eventChan t
+    }
+
+simpleOnePlaceQDisc :: IO (QDisc t)
+simpleOnePlaceQDisc = do
+  onePlaceQueue <- newEmptyMVar
+  return $ QDisc {
+      qdiscDequeue = takeMVar onePlaceQueue
+    , qdiscEnqueue = \_ _ t -> putMVar onePlaceQueue t
+    }
+```
+
+`qdiscDequeue` will be used by `receive` to get the next `Event`, whereas
+`qdiscEnqueue` will be used by the thread which processes a socket to put
+its `Event` into the queue. Crucially: if `qdiscEnqueue` blocks, then
+socket reads stop until it unblocks. The unbounded `QDisc` never blocks on
+enqueue, and so socket reading never stops, whereas the bounded `QDisc` *will*
+block and hold up the socket in case the program is not dequeueing the `Event`s
+at a sufficiently high rate.
+
+By choosing a `QDisc` which intelligently blocks on `qdiscEnqueue`, perhaps in
+response to shared mutable state informed by various application-specific
+metrics, the rate of input from peers can be controlled so as to eliminate
+excessive load and to maximize quality of service for all peers.
+
+## Example
+
+Perhaps the best way to appreciate what's described above is to watch the
+phenomenon as it happens. The program `examples/abuse/Main.hs` implements a
+client and a server, along with live monitoring of the server's health:
+its heap size and productivity (time spent doing non-garbage-collector work),
+among other things. The client sends 16mb payloads to the server as fast
+as possible, and the server receives them, calculates their length, and
+maintains a tally of the total number of bytes received. Here's how you can run
+it:
+
+```bash
+stack build
+stack exec ghc examples/abuse/Main -- -threaded
+
+# Start the server using an unbounded QDisc. -T is required for monitoring.
+# -N1 is chosen to make the server respond rather slowly compared to the
+# client's send rate.
+./examples/abuse/Main server 7777 unbounded +RTS -N1 -T
+
+# Open the EKG console.
+<your_graphical_web_browser> localhost:8000
+
+# Start the client. Choose -N so that on multicore systems it's given more
+# capabilities than the server.
+./examples/abuse/Main client 7777 7778 +RTS -N
+```
+
+Watch the EKG web dashboard. The heap residency will grow without bound
+until your OS kills the server. Now try that again, replacing `unbounded` with
+`one_place` in the server command. This time, the residency will remain under 
+control, as the client's TCP send buffers fill up and sending slows down.
+These results were gathered on an Intel i5 with 4 cores at 2.50GHz, 8Gb RAM.
+
+## Future work
+
+The `simpleOnePlaceQDisc` is effective but indeed *simple*. Moving forward,
+we'll want a more sophisticated `QDisc` capable of prioritizing traffic
+according to various metrics. One idea is to deprioritize traffic from peers
+which have an inordinate amount of in-flight data, effectively limiting the
+amount of in-flight data per-peer.

--- a/src/Network/Transport/Abstract.hs
+++ b/src/Network/Transport/Abstract.hs
@@ -105,5 +105,5 @@ instance Binary EventError
 -- | A queueing discipline.
 data QDisc m t = QDisc {
       qdiscDequeue :: m t
-    , qdiscEnqueue :: Event -> t -> m ()
+    , qdiscEnqueue :: NT.EndPointAddress -> Event -> t -> m ()
     }

--- a/src/Network/Transport/Concrete/TCP.hs
+++ b/src/Network/Transport/Concrete/TCP.hs
@@ -18,5 +18,5 @@ concreteQDisc
     -> TCP.QDisc t
 concreteQDisc lowerIO qdisc = TCP.QDisc {
       TCP.qdiscDequeue = lowerIO $ qdiscDequeue qdisc
-    , TCP.qdiscEnqueue = \addr event -> lowerIO . qdiscEnqueue qdisc (C.concreteEvent event)
+    , TCP.qdiscEnqueue = \addr event -> lowerIO . qdiscEnqueue qdisc addr (C.concreteEvent event)
     }

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -25,7 +25,7 @@ module Node (
     , messageName'
 
     , SendActions(sendTo, withConnectionTo)
-    , ConversationActions(send, recv, peerData)
+    , ConversationActions(send, recv)
     , Worker
     , Listener
     , ListenerAction(..)
@@ -92,7 +92,7 @@ data ListenerAction packing peerData m where
   -- | A listener that handles an incoming bi-directional conversation.
   ListenerActionConversation
     :: ( Packable packing snd, Unpackable packing rcv, Message rcv )
-    => (peerData -> LL.NodeId -> ConversationActions peerData snd rcv m -> m ())
+    => (peerData -> LL.NodeId -> ConversationActions snd rcv m -> m ())
     -> ListenerAction packing peerData m
 
 hoistListenerAction
@@ -112,12 +112,13 @@ listenerMessageName (ListenerActionOneMsg (
     )) = messageName (Proxy :: Proxy msg)
 
 listenerMessageName (ListenerActionConversation (
-        _ :: peerData -> LL.NodeId -> ConversationActions peerData snd rcv m -> m ()
+        _ :: peerData -> LL.NodeId -> ConversationActions snd rcv m -> m ()
     )) = messageName (Proxy :: Proxy rcv)
 
 data SendActions packing peerData m = SendActions {
        -- | Send a isolated (sessionless) message to a node
-       sendTo :: forall msg .
+       sendTo
+           :: forall msg .
               ( Packable packing msg, Message msg )
               => LL.NodeId
               -> msg
@@ -128,34 +129,28 @@ data SendActions packing peerData m = SendActions {
            :: forall snd rcv t .
             ( Packable packing snd, Message snd, Unpackable packing rcv )
            => LL.NodeId
-           -> (ConversationActions peerData snd rcv m -> m t)
+           -> (m peerData -> ConversationActions snd rcv m -> m t)
            -> m t
      }
 
-data ConversationActions peerData body rcv m = ConversationActions {
+data ConversationActions body rcv m = ConversationActions {
        -- | Send a message within the context of this conversation
        send     :: body -> m ()
 
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).
-     , recv     :: m (Maybe rcv)
-
-       -- | The data associated with that peer (reported by the peer).
-       --   It's in m because trying to take it may block (it may not be
-       --   known yet!).
-     , peerData :: m peerData
+     , recv :: m (Maybe rcv)
      }
 
 hoistConversationActions
     :: (forall a. n a -> m a)
-    -> ConversationActions peerData body rcv n
-    -> ConversationActions peerData body rcv m
+    -> ConversationActions body rcv n
+    -> ConversationActions body rcv m
 hoistConversationActions nat ConversationActions {..} =
-  ConversationActions send' recv' peerData'
+  ConversationActions send' recv'
       where
         send' = nat . send
         recv' = nat recv
-        peerData' = nat peerData
 
 hoistSendActions
     :: (forall a. n a -> m a)
@@ -166,7 +161,9 @@ hoistSendActions nat rnat SendActions {..} = SendActions sendTo' withConnectionT
   where
     sendTo' nodeId msg = nat $ sendTo nodeId msg
     withConnectionTo' nodeId convActionsH =
-        nat $ withConnectionTo nodeId  $ \convActions -> rnat $ convActionsH $ hoistConversationActions nat convActions
+        nat $ withConnectionTo nodeId  $ \peerData convActions -> rnat $
+            convActionsH (nat peerData) $
+            hoistConversationActions nat convActions
 
 type ListenerIndex packing peerData m =
     Map MessageName (ListenerAction packing peerData m)
@@ -215,16 +212,16 @@ nodeSendActions nodeUnit packing =
         :: forall snd rcv t .
            ( Packable packing snd, Message snd, Unpackable packing rcv )
         => LL.NodeId
-        -> (ConversationActions peerData snd rcv m -> m t)
+        -> (m peerData -> ConversationActions snd rcv m -> m t)
         -> m t
     nodeWithConnectionTo = \nodeId f ->
         LL.withInOutChannel nodeUnit nodeId $ \peerDataVar inchan outchan -> do
             let msgName  = messageName (Proxy :: Proxy snd)
-                cactions :: ConversationActions peerData snd rcv m
-                cactions = nodeConversationActions nodeUnit nodeId packing (readSharedExclusive peerDataVar) inchan outchan
+                cactions :: ConversationActions snd rcv m
+                cactions = nodeConversationActions nodeUnit nodeId packing inchan outchan
             LL.writeChannel outchan . LBS.toChunks $
                 packMsg packing msgName
-            f cactions
+            f (readSharedExclusive peerDataVar) cactions
 
 -- | Conversation actions for a given peer and in/out channels.
 nodeConversationActions
@@ -237,12 +234,11 @@ nodeConversationActions
     => LL.Node packing peerData m
     -> LL.NodeId
     -> packing
-    -> m peerData
     -> ChannelIn m
     -> ChannelOut m
-    -> ConversationActions peerData snd rcv m
-nodeConversationActions _ _ packing peerData inchan outchan =
-    ConversationActions nodeSend nodeRecv peerData
+    -> ConversationActions snd rcv m
+nodeConversationActions _ _ packing inchan outchan =
+    ConversationActions nodeSend nodeRecv
     where
 
     nodeSend = \body -> do
@@ -368,7 +364,7 @@ node transport prng packing peerData k = do
                 let listener = M.lookup msgName listenerIndex
                 case listener of
                     Just (ListenerActionConversation action) ->
-                        let cactions = nodeConversationActions nodeUnit peerId packing (return peerData) inchan outchan
+                        let cactions = nodeConversationActions nodeUnit peerId packing inchan outchan
                         in  action peerData peerId cactions
                     Just (ListenerActionOneMsg _) -> error ("handlerInOut : wrong listener type. Expected bidirectional for " ++ show msgName)
                     Nothing -> error ("handlerInOut : no listener for " ++ show msgName)

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -231,12 +231,12 @@ deliveryTest testState workers listeners = runProduction $ do
     let prng2 = mkStdGen 1
 
     -- launch nodes
-    node transport prng1 BinaryP () $ \serverNode -> do
+    node transport prng1 BinaryP () $ \serverNode ->
         -- Server EndPoint is up.
-        pure $ NodeAction listeners $ \_ -> do
-            node transport prng2 BinaryP () $ \_ -> do
+        NodeAction listeners $ \_ -> do
+            node transport prng2 BinaryP () $ \_ ->
                 -- Client EndPoint is up.
-                pure $ NodeAction [] $ \clientSendActions -> do
+                NodeAction [] $ \clientSendActions -> do
                     void . forConcurrently workers $ \worker ->
                         worker (nodeId serverNode) clientSendActions
                     -- Client EndPoint closes here

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -185,7 +185,7 @@ sendAll SingleMessageStyle sendActions peerId msgs =
     forM_ msgs $ sendTo sendActions peerId
 
 sendAll ConversationStyle sendActions peerId msgs =
-    void . withConnectionTo sendActions @_ @Bool peerId $ \cactions -> forM_ msgs $
+    void . withConnectionTo sendActions @_ @Bool peerId $ \peerData cactions -> forM_ msgs $
     \msg -> do
         send cactions msg
         _ <- recv cactions


### PR DESCRIPTION
See the [README](https://github.com/serokell/time-warp-nt/blob/ac0cf3c3c64b56b92ac3609fb0fa6d9215d3ee01/examples/abuse/README.md)

Also included in this PR are fixes for some mistakes which were uncovered while writing up documentation.

- The type of `Node.node` changes: the `NodeActions` (which includes the listeners) must be computed purely (rather than in `m`) and can use the components of the `Node` itself only lazily. That's because the listeners must be defined *prior* to the end point being brought up. Prior to this change there was a gap in time between bringing the end point up, and defining the listeners, so it was possible (though highly unlikely) that the system would try to run a listener which is not yet defined.
- The definition of `Node.ConversationActions` changes so that it no longer includes `peerData :: m peerData`. This was originally included so that the `ConversationActions` given to `withConnectionTo` would provide the initiating peer with the receiving peer's data once it is available (hence the `m peerData` rather than just `peerData`). However, `ConversationActions` is also given to a conversation listener, which already has the peer data available, so there was a confusing and unnecessary duplication there. Now, the peer data is given as another argument to the continuation of `withConnectionTo`.