### PR TITLE
Various bug fixes concerning outbound bidirectional connections

### DIFF
--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -66,7 +66,6 @@ Library
                       , mtl
                       , network
                       , network-transport
-                      , network-transport-inmemory
                       , network-transport-tcp
                       , mtl >= 2.2.1
                       , random
@@ -98,7 +97,6 @@ executable discovery
                       , binary
                       , bytestring
                       , containers
-                      , network-transport-inmemory
                       , network-transport-tcp
                       , node-sketch
                       , random
@@ -118,7 +116,6 @@ executable ping-pong
   build-depends:       base >= 4.8 && < 5
                      , binary
                      , bytestring
-                     , network-transport-inmemory
                      , network-transport-tcp
                      , node-sketch
                      , random
@@ -226,7 +223,6 @@ test-suite node-sketch-test
                      , hspec >= 2.1.10
                      , lens >= 4.14
                      , mtl >= 2.2.1
-                     , network-transport-inmemory
                      , network-transport-tcp
                      , node-sketch
                      , QuickCheck

--- a/src/Network/Transport/Abstract.hs
+++ b/src/Network/Transport/Abstract.hs
@@ -12,6 +12,7 @@ module Network.Transport.Abstract
   , Event(..)
   , QDisc(..)
   , NT.ConnectionId
+  , NT.ConnectionBundle
   , NT.Reliability(..)
   , NT.EndPointAddress(..)
     -- * Hints
@@ -76,6 +77,7 @@ data Connection m = Connection {
     send :: [ByteString] -> m (Either (NT.TransportError NT.SendErrorCode) ())
     -- | Close the connection.
   , close :: m ()
+  , bundle :: NT.ConnectionBundle
   }
 
 -- | Event on an endpoint.

--- a/src/Network/Transport/Concrete.hs
+++ b/src/Network/Transport/Concrete.hs
@@ -58,4 +58,5 @@ concreteConnection :: ( MonadIO m ) => NT.Connection -> Connection m
 concreteConnection ntConnection = Connection {
       send = liftIO . NT.send ntConnection
     , close = liftIO $ NT.close ntConnection
+    , bundle = NT.bundle ntConnection
     }

--- a/src/Network/Transport/Concrete/TCP.hs
+++ b/src/Network/Transport/Concrete/TCP.hs
@@ -18,5 +18,5 @@ concreteQDisc
     -> TCP.QDisc t
 concreteQDisc lowerIO qdisc = TCP.QDisc {
       TCP.qdiscDequeue = lowerIO $ qdiscDequeue qdisc
-    , TCP.qdiscEnqueue = \event -> lowerIO . qdiscEnqueue qdisc (C.concreteEvent event)
+    , TCP.qdiscEnqueue = \addr event -> lowerIO . qdiscEnqueue qdisc (C.concreteEvent event)
     }

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -293,11 +293,17 @@ node transport prng packing peerData k = do
               (listenerIndex, _conflictingNames) = makeListenerIndex listeners
         ; let sendActions = nodeSendActions llnode packing
         }
-    act sendActions `finally` LL.stopNode llnode `catch` logException
+    act sendActions `catch` logException
+                    `finally` LL.stopNode llnode
+                    `catch` logNodeException
   where
     logException :: SomeException -> m t
     logException e = do
         logError (sformat ("node stopped with exception " % shown) e)
+        throw e
+    logNodeException :: SomeException -> m t
+    logNodeException e = do
+        logError (sformat ("exception while stopping node " % shown) e)
         throw e
     -- Handle incoming data from unidirectional connections: try to read the
     -- message name, use it to determine a listener, parse the body, then

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -830,7 +830,6 @@ nodeDispatcher node handlerIn handlerInOut =
         -- Waiting for a handshake. Try to get a control header and then
         -- move on.
         Just (peer, WaitingForHandshake peerData partial) -> do
-            -- TODO the handshake.
             let bytes = BS.append partial (BS.concat chunks)
             case BS.uncons bytes of
 
@@ -854,7 +853,9 @@ nodeDispatcher node handlerIn handlerInOut =
                     -- nonce.
                     | w == controlHeaderCodeBidirectionalSyn ||
                       w == controlHeaderCodeBidirectionalAck
-                    , BS.length ws < 8 -> return state
+                    , BS.length ws < 8 -> return $ state {
+                            csConnections = Map.insert connid (peer, WaitingForHandshake peerData bytes) (csConnections state)
+                          }
 
                     -- Got a SYN. Spawn a thread to connect to the peer using
                     -- the nonce provided and then run the bidirectional handler.

--- a/src/Node/Util/Monitor.hs
+++ b/src/Node/Util/Monitor.hs
@@ -5,10 +5,12 @@
 module Node.Util.Monitor (
 
       setupMonitor
+    , stopMonitor
 
     ) where
 
 import Control.Monad.IO.Class
+import Control.Concurrent (killThread)
 import Mockable.Class
 import qualified Mockable.Metrics as Metrics
 import qualified System.Remote.Monitoring as Monitoring
@@ -47,3 +49,9 @@ setupMonitor port lowerIO node = do
     server <- liftIO $ Monitoring.forkServerWith store "127.0.0.1" port
     liftIO . putStrLn $ "Forked EKG server on port " ++ show port
     return server
+
+stopMonitor
+    :: ( MonadIO m )
+    => Monitoring.Server
+    -> m ()
+stopMonitor server = liftIO $ killThread (Monitoring.serverThreadId server)

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,11 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-tcp
-      commit: 6cef5a6120d1aa7b87c270a95149bc69403c1376
+      commit: 705b3c0d44cb1f4eea904b54431cd467e62dda35
+    extra-dep: true
+  - location:
+      git: https://github.com/avieth/network-transport
+      commit: e7a5f44d0d98370d16df103c9dc61ef7bf15aee8
     extra-dep: true
 
 extra-deps:


### PR DESCRIPTION
- Use custom network-transport and network-transport-tcp branches which implement `ConnectionBundle` identifiers, and provide more regular `ConnectionClosed` events (for instance, if a connection is lost, all open lightweight connections are reported closed). Relevant nt issue https://github.com/haskell-distributed/network-transport/issues/33
- Sharpen exception reporting in node: exceptions in the action versus exceptions in trying to stop the node itself.
- Fix a bug in the dispatcher in which partial control headers would be incorrectly parsed.
- Eliminate races in connecting/disconnecting from a peer and determining which connection should send the peer data.
- Always plug the input channels on un-ACK'd locally-initiated conversation handlers.