### PR TITLE
Fill peer data exclusive on errors; improve logging

### DIFF
--- a/src/Mockable/Exception.hs
+++ b/src/Mockable/Exception.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Mockable.Exception (
 
@@ -11,6 +12,7 @@ module Mockable.Exception (
     , bracket
     , bracketWithException
     , finally
+    , onException
 
     , Throw(..)
     , throw
@@ -55,6 +57,9 @@ bracketWithException acquire release act = liftMockable $ BracketWithException a
 
 finally :: ( Mockable Bracket m ) => m a -> m b -> m a
 finally act end = bracket (return ()) (const end) (const act)
+
+onException :: ( Mockable Catch m, Mockable Throw m ) => m a -> m b -> m a
+onException act ex = act `catch` (\(e :: SomeException) -> ex >> throw e)
 
 data Throw (m :: * -> *) (t :: *) where
     Throw :: Exception e => e -> Throw m t

--- a/src/Mockable/Monad.hs
+++ b/src/Mockable/Monad.hs
@@ -9,7 +9,7 @@ module Mockable.Monad
 
 import           Mockable.Channel         (Channel)
 import           Mockable.Class           (Mockable)
-import           Mockable.Concurrent      (Async, Concurrently, Delay, Fork, Promise)
+import           Mockable.Concurrent      (Async, Concurrently, Delay, Fork, ThreadId)
 import           Mockable.CurrentTime     (CurrentTime)
 import           Mockable.Exception       (Bracket, Catch, Throw)
 import           Mockable.Metrics         (Metrics)
@@ -28,7 +28,8 @@ type MonadMockable m
       , Mockable Channel m
       , Mockable Throw m
       , Mockable Catch m
-      , Ord (Promise m ())
+      , Ord (ThreadId m)
+      , Show (ThreadId m)
       , Mockable SharedExclusive m
       , Mockable Metrics m
       )

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -95,6 +95,8 @@ instance Mockable SharedExclusive Production where
         = Production $ Conc.takeMVar var
     liftMockable (ModifySharedExclusive var f)
         = Production $ Conc.modifyMVar var (runProduction . f)
+    liftMockable (TryPutSharedExclusive var t)
+        = Production $ Conc.tryPutMVar var t
 
 type instance ChannelT Production = Conc.TChan
 

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -68,9 +68,11 @@ type instance Promise Production = Conc.Async
 
 instance Mockable Async Production where
     liftMockable (Async m)          = Production $ Conc.async (runProduction m)
+    liftMockable (WithAsync m k)    = Production $ Conc.withAsync (runProduction m) (runProduction . k)
     liftMockable (Wait promise)     = Production $ Conc.wait promise
     liftMockable (WaitAny promises) = Production $ Conc.waitAny promises
     liftMockable (Cancel promise)   = Production $ Conc.cancel promise
+    liftMockable (AsyncThreadId p)  = Production $ return (Conc.asyncThreadId p)
 
 instance Mockable Concurrently Production where
     liftMockable (Concurrently a b) = Production $

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-tcp
-      commit: 705b3c0d44cb1f4eea904b54431cd467e62dda35
+      commit: d2705abd5b54707ca97b5bf9c9c24005e800ee49
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport


### PR DESCRIPTION
Just as we must plug the input channels of outbound handlers when the endpoint closes or a connection is lost, we must also fill the peer data MVar, or else the handlers may block indefinitely.

These cases were revealed by cardano-node. In that program, it's quite common for a handler to try to do its thing even though the node has gone down normally (time slave before real node).