### PR TITLE
Improve testing, fix race on bidirectional connections

### DIFF
--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -227,7 +227,9 @@ test-suite node-sketch-test
                      , hspec >= 2.1.10
                      , lens >= 4.14
                      , mtl >= 2.2.1
+                     , network-transport
                      , network-transport-tcp
+                     , network-transport-inmemory
                      , node-sketch
                      , QuickCheck
                      , quickcheck-instances

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-tcp
-      commit: d2705abd5b54707ca97b5bf9c9c24005e800ee49
+      commit: 8fb61171a0f09e554c051ca112e3967cea6b7f69
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,10 @@ packages:
       git: https://github.com/avieth/network-transport
       commit: e7a5f44d0d98370d16df103c9dc61ef7bf15aee8
     extra-dep: true
+  - location:
+      git: https://github.com/avieth/network-transport-inmemory
+      commit: c6893b17531ed47838c8d8f0bf434cf0119b50df
+    extra-dep: true
 
 extra-deps:
   - network-transport-inmemory-0.5.2

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,5 +1,6 @@
-import           Spec       (spec)
+import           Test.NodeSpec (spec)
 import           Test.Hspec (hspec)
+import           Test.Util (makeTCPTransport, makeInMemoryTransport)
 
 main :: IO ()
 main = hspec spec

--- a/test/Test/NodeSpec.hs
+++ b/test/Test/NodeSpec.hs
@@ -18,7 +18,7 @@ import           Control.Lens                (sans, (%=), (&~), (.=))
 import           Data.Foldable               (for_)
 import qualified Data.Set                    as S
 import           Data.Time.Units             (Microsecond)
-import           Test.Hspec                  (Spec, describe, runIO)
+import           Test.Hspec                  (Spec, describe, runIO, afterAll_)
 import           Test.Hspec.QuickCheck       (prop)
 import           Test.QuickCheck             (Property, ioProperty)
 import           Test.QuickCheck.Modifiers   (NonEmptyList(..), getNonEmpty)
@@ -30,6 +30,9 @@ import           Test.Util                   (HeavyParcel (..), Parcel (..),
                                               Payload(..), timeout)
 import           System.Random               (newStdGen)
 import qualified Network.Transport           as NT (Transport)
+import qualified Network.Transport.Abstract  as NT (closeTransport)
+import           Network.Transport.TCP       (simpleOnePlaceQDisc)
+import           Network.QDisc.Fair          (fairQDisc)
 import           Network.Transport.Concrete  (concrete)
 import           Mockable.Class              (Mockable)
 import           Mockable.SharedExclusive    (newSharedExclusive, readSharedExclusive,
@@ -43,99 +46,107 @@ import           Node
 spec :: Spec
 spec = describe "Node" $ do
 
-    tcpTransport <- runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10342"
-    memoryTransport <- runIO $ makeInMemoryTransport
-    let transports = [("In-memory", memoryTransport), ("TCP", tcpTransport)]
+    let tcpTransportOnePlace = runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10342" simpleOnePlaceQDisc
+    let tcpTransportFair = runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10343" fairQDisc
+    let memoryTransport = runIO $ makeInMemoryTransport
+    let transports = [
+              ("In-memory", memoryTransport)
+            , ("TCP", tcpTransportOnePlace)
+            , ("TCP fair queueing", tcpTransportFair)
+            ]
 
-    forM_ transports $ \(name, transport_) -> describe ("Using transport: " ++ name) $ do
+    forM_ transports $ \(name, mkTransport) -> do
 
+        transport_ <- mkTransport
         let transport = concrete transport_
 
-        prop "peer data" $ ioProperty . runProduction $ do
-            clientGen <- liftIO newStdGen
-            serverGen <- liftIO newStdGen
-            serverAddressVar <- newSharedExclusive
-            clientFinished <- newSharedExclusive
-            serverFinished <- newSharedExclusive
-            let attempts = 1
+        describe ("Using transport: " ++ name) $ afterAll_ (runProduction (NT.closeTransport transport)) $ do
 
-            let listener = ListenerActionConversation $ \pd _ cactions -> do
-                    True <- return $ pd == ("client", 24)
-                    initial <- timeout "server waiting for request" 30000000 (recv cactions)
-                    case initial of
-                        Nothing -> error "got no initial message"
-                        Just (Parcel i (Payload _)) -> do
-                            _ <- timeout "server sending response" 30000000 (send cactions (Parcel i (Payload 32)))
-                            return ()
+            prop "peer data" $ ioProperty . runProduction $ do
+                clientGen <- liftIO newStdGen
+                serverGen <- liftIO newStdGen
+                serverAddressVar <- newSharedExclusive
+                clientFinished <- newSharedExclusive
+                serverFinished <- newSharedExclusive
+                let attempts = 1
 
-            let server = node transport serverGen BinaryP ("server" :: String, 42 :: Int) $ \_node ->
+                let listener = ListenerActionConversation $ \pd _ cactions -> do
+                        True <- return $ pd == ("client", 24)
+                        initial <- timeout "server waiting for request" 30000000 (recv cactions)
+                        case initial of
+                            Nothing -> error "got no initial message"
+                            Just (Parcel i (Payload _)) -> do
+                                _ <- timeout "server sending response" 30000000 (send cactions (Parcel i (Payload 32)))
+                                return ()
+
+                let server = node transport serverGen BinaryP ("server" :: String, 42 :: Int) $ \_node ->
+                        NodeAction [listener] $ \sendActions -> do
+                            putSharedExclusive serverAddressVar (nodeId _node)
+                            takeSharedExclusive clientFinished
+                            putSharedExclusive serverFinished ()
+
+                let client = node transport clientGen BinaryP ("client" :: String, 24 :: Int) $ \_node ->
+                        NodeAction [listener] $ \sendActions -> do
+                            serverAddress <- readSharedExclusive serverAddressVar
+                            forM_ [1..attempts] $ \i -> withConnectionTo sendActions serverAddress $ \peerData cactions -> do
+                                pd <- timeout "client waiting for peer data" 30000000 peerData
+                                True <- return $ pd == ("server", 42)
+                                _ <- timeout "client sending" 30000000 (send cactions (Parcel i (Payload 32)))
+                                response <- timeout "client waiting for response" 30000000 (recv cactions)
+                                case response of
+                                    Nothing -> error "got no response"
+                                    Just (Parcel j (Payload _)) -> do
+                                        when (j /= i) (error "parcel number mismatch")
+                                        return ()
+                            putSharedExclusive clientFinished ()
+                            takeSharedExclusive serverFinished
+
+                withAsync server $ \serverPromise -> do
+                    withAsync client $ \clientPromise -> do
+                        wait clientPromise
+                        wait serverPromise
+
+                return True
+
+            -- Test where a node converses with itself. Fails only if an exception is
+            -- thrown.
+            prop "self connection" $ ioProperty . runProduction $ do
+                gen <- liftIO newStdGen
+                -- Self-connections don't make TCP sockets so we can do an absurd amount
+                -- of attempts without taking too much time.
+                let attempts = 100
+
+                let listener = ListenerActionConversation $ \pd _ cactions -> do
+                        True <- return $ pd == ("some string", 42)
+                        initial <- recv cactions
+                        case initial of
+                            Nothing -> error "got no initial message"
+                            Just (Parcel i (Payload _)) -> do
+                                _ <- send cactions (Parcel i (Payload 32))
+                                return ()
+
+                node transport gen BinaryP ("some string" :: String, 42 :: Int) $ \_node ->
                     NodeAction [listener] $ \sendActions -> do
-                        putSharedExclusive serverAddressVar (nodeId _node)
-                        takeSharedExclusive clientFinished
-                        putSharedExclusive serverFinished ()
-
-            let client = node transport clientGen BinaryP ("client" :: String, 24 :: Int) $ \_node ->
-                    NodeAction [listener] $ \sendActions -> do
-                        serverAddress <- readSharedExclusive serverAddressVar
-                        forM_ [1..attempts] $ \i -> withConnectionTo sendActions serverAddress $ \peerData cactions -> do
+                        forM_ [1..attempts] $ \i -> withConnectionTo sendActions (nodeId _node) $ \peerData cactions -> do
                             pd <- timeout "client waiting for peer data" 30000000 peerData
-                            True <- return $ pd == ("server", 42)
-                            _ <- timeout "client sending" 30000000 (send cactions (Parcel i (Payload 32)))
-                            response <- timeout "client waiting for response" 30000000 (recv cactions)
+                            True <- return $ pd == ("some string", 42)
+                            _ <- send cactions (Parcel i (Payload 32))
+                            response <- recv cactions
                             case response of
                                 Nothing -> error "got no response"
                                 Just (Parcel j (Payload _)) -> do
                                     when (j /= i) (error "parcel number mismatch")
                                     return ()
-                        putSharedExclusive clientFinished ()
-                        takeSharedExclusive serverFinished
+                return True
 
-            withAsync server $ \serverPromise -> do
-                withAsync client $ \clientPromise -> do
-                    wait clientPromise
-                    wait serverPromise
-
-            return True
-
-        -- Test where a node converses with itself. Fails only if an exception is
-        -- thrown.
-        prop "self connection" $ ioProperty . runProduction $ do
-            gen <- liftIO newStdGen
-            -- Self-connections don't make TCP sockets so we can do an absurd amount
-            -- of attempts without taking too much time.
-            let attempts = 100
-
-            let listener = ListenerActionConversation $ \pd _ cactions -> do
-                    True <- return $ pd == ("some string", 42)
-                    initial <- recv cactions
-                    case initial of
-                        Nothing -> error "got no initial message"
-                        Just (Parcel i (Payload _)) -> do
-                            _ <- send cactions (Parcel i (Payload 32))
-                            return ()
-
-            node transport gen BinaryP ("some string" :: String, 42 :: Int) $ \_node ->
-                NodeAction [listener] $ \sendActions -> do
-                    forM_ [1..attempts] $ \i -> withConnectionTo sendActions (nodeId _node) $ \peerData cactions -> do
-                        pd <- timeout "client waiting for peer data" 30000000 peerData
-                        True <- return $ pd == ("some string", 42)
-                        _ <- send cactions (Parcel i (Payload 32))
-                        response <- recv cactions
-                        case response of
-                            Nothing -> error "got no response"
-                            Just (Parcel j (Payload _)) -> do
-                                when (j /= i) (error "parcel number mismatch")
-                                return ()
-            return True
-
-        -- one sender, one receiver
-        describe "delivery" $ do
-            for_ [SingleMessageStyle, ConversationStyle] $ \talkStyle ->
-                describe (show talkStyle) $ do
-                    prop "plain" $
-                        plainDeliveryTest transport_ talkStyle
-                    prop "heavy messages sent nicely" $
-                        withHeavyParcels $ plainDeliveryTest transport_ talkStyle
+            -- one sender, one receiver
+            describe "delivery" $ do
+                for_ [SingleMessageStyle, ConversationStyle] $ \talkStyle ->
+                    describe (show talkStyle) $ do
+                        prop "plain" $
+                            plainDeliveryTest transport_ talkStyle
+                        prop "heavy messages sent nicely" $
+                            withHeavyParcels $ plainDeliveryTest transport_ talkStyle
 
 prepareDeliveryTestState :: [Parcel] -> IO (TVar TestState)
 prepareDeliveryTestState expectedParcels =

--- a/test/Test/NodeSpec.hs
+++ b/test/Test/NodeSpec.hs
@@ -5,34 +5,160 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE BangPatterns        #-}
 
 module Test.NodeSpec
        ( spec
        ) where
 
+import           Control.Monad               (forM_, when)
+import           Control.Monad.IO.Class      (liftIO)
 import           Control.Concurrent.STM.TVar (TVar, newTVarIO)
 import           Control.Lens                (sans, (%=), (&~), (.=))
 import           Data.Foldable               (for_)
 import qualified Data.Set                    as S
-import           Test.Hspec                  (Spec, describe)
+import           Data.Time.Units             (Microsecond)
+import           Test.Hspec                  (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck       (prop)
 import           Test.QuickCheck             (Property, ioProperty)
 import           Test.QuickCheck.Modifiers   (NonEmptyList(..), getNonEmpty)
 import           Test.Util                   (HeavyParcel (..), Parcel (..),
                                               TalkStyle (..), TestState, deliveryTest,
                                               expected, mkTestState, modifyTestState,
-                                              newWork, receiveAll, sendAll)
+                                              newWork, receiveAll, sendAll,
+                                              makeTCPTransport, makeInMemoryTransport,
+                                              Payload(..))
+import           System.Random               (newStdGen)
+import qualified Network.Transport           as NT (Transport)
+import           Network.Transport.Concrete  (concrete)
+import           Mockable.Class              (Mockable)
+import           Mockable.SharedExclusive    (newSharedExclusive, readSharedExclusive,
+                                              putSharedExclusive, takeSharedExclusive,
+                                              tryPutSharedExclusive, SharedExclusive)
+import           Mockable.Concurrent         (withAsync, wait, Async, Delay, delay)
+import           Mockable.Production         (runProduction)
+import           Node.Message                (BinaryP(..))
+import           Node
+
+timeout
+    :: ( Mockable Delay m
+       , Mockable Async m
+       , Mockable SharedExclusive m
+       )
+    => String
+    -> Microsecond
+    -> m t
+    -> m t
+timeout str us m = do
+    var <- newSharedExclusive
+    let action = do
+            t <- m
+            tryPutSharedExclusive var t
+            return ()
+    let timeoutAction = do
+            delay us
+            tryPutSharedExclusive var (error $ str ++ " : timeout after " ++ show us)
+            return ()
+    withAsync action $ \actionPromise -> do
+        withAsync timeoutAction $ \timeoutPromise -> do
+            readSharedExclusive var
 
 spec :: Spec
-spec = describe "Node" $
-    -- one sender, one receiver
-    describe "delivery" $ do
-        for_ [SingleMessageStyle, ConversationStyle] $ \talkStyle ->
-            describe (show talkStyle) $ do
-                prop "plain" $
-                    plainDeliveryTest talkStyle
-                prop "heavy messages sent nicely" $
-                    withHeavyParcels $ plainDeliveryTest talkStyle
+spec = describe "Node" $ do
+
+    tcpTransport <- runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10342"
+    memoryTransport <- runIO $ makeInMemoryTransport
+    let transports = [("TCP", tcpTransport), ("In-memory", memoryTransport)]
+
+    forM_ transports $ \(name, transport_) -> describe ("Using transport: " ++ name) $ do
+
+        let transport = concrete transport_
+
+        prop "peer data" $ ioProperty . runProduction $ do
+            clientGen <- liftIO newStdGen
+            serverGen <- liftIO newStdGen
+            serverAddressVar <- newSharedExclusive
+            clientFinished <- newSharedExclusive
+            serverFinished <- newSharedExclusive
+            let attempts = 1
+
+            let listener = ListenerActionConversation $ \pd _ cactions -> do
+                    True <- return $ pd == ("client", 24)
+                    initial <- timeout "server waiting for request" 1000000 (recv cactions)
+                    case initial of
+                        Nothing -> error "got no initial message"
+                        Just (Parcel i (Payload _)) -> do
+                            _ <- timeout "server sending response" 1000000 (send cactions (Parcel i (Payload 32)))
+                            return ()
+
+            let server = node transport serverGen BinaryP ("server" :: String, 42 :: Int) $ \_node ->
+                    NodeAction [listener] $ \sendActions -> do
+                        putSharedExclusive serverAddressVar (nodeId _node)
+                        takeSharedExclusive clientFinished
+                        putSharedExclusive serverFinished ()
+
+            let client = node transport clientGen BinaryP ("client" :: String, 24 :: Int) $ \_node ->
+                    NodeAction [listener] $ \sendActions -> do
+                        serverAddress <- readSharedExclusive serverAddressVar
+                        forM_ [1..attempts] $ \i -> withConnectionTo sendActions serverAddress $ \peerData cactions -> do
+                            pd <- timeout "client waiting for peer data" 1000000 peerData
+                            True <- return $ pd == ("server", 42)
+                            _ <- timeout "client sending" 1000000 (send cactions (Parcel i (Payload 32)))
+                            response <- timeout "client waiting for response" 100000 (recv cactions)
+                            case response of
+                                Nothing -> error "got no response"
+                                Just (Parcel j (Payload _)) -> do
+                                    when (j /= i) (error "parcel number mismatch")
+                                    return ()
+                        putSharedExclusive clientFinished ()
+                        takeSharedExclusive serverFinished
+
+            withAsync server $ \serverPromise -> do
+                withAsync client $ \clientPromise -> do
+                    wait clientPromise
+                    wait serverPromise
+
+            return True
+
+        -- Test where a node converses with itself. Fails only if an exception is
+        -- thrown.
+        prop "self connection" $ ioProperty . runProduction $ do
+            gen <- liftIO newStdGen
+            -- Self-connections don't make TCP sockets so we can do an absurd amount
+            -- of attempts without taking too much time.
+            let attempts = 1000
+
+            let listener = ListenerActionConversation $ \pd _ cactions -> do
+                    True <- return $ pd == ("some string", 42)
+                    initial <- recv cactions
+                    case initial of
+                        Nothing -> error "got no initial message"
+                        Just (Parcel i (Payload _)) -> do
+                            _ <- send cactions (Parcel i (Payload 32))
+                            return ()
+
+            node transport gen BinaryP ("some string" :: String, 42 :: Int) $ \_node ->
+                NodeAction [listener] $ \sendActions -> do
+                    forM_ [1..attempts] $ \i -> withConnectionTo sendActions (nodeId _node) $ \peerData cactions -> do
+                        pd <- timeout "client waiting for peer data" 1000000 peerData
+                        True <- return $ pd == ("some string", 42)
+                        _ <- send cactions (Parcel i (Payload 32))
+                        response <- recv cactions
+                        case response of
+                            Nothing -> error "got no response"
+                            Just (Parcel j (Payload _)) -> do
+                                when (j /= i) (error "parcel number mismatch")
+                                return ()
+            return True
+
+        -- one sender, one receiver
+        describe "delivery" $ do
+            for_ [SingleMessageStyle, ConversationStyle] $ \talkStyle ->
+                describe (show talkStyle) $ do
+                    prop "plain" $
+                        plainDeliveryTest transport_ talkStyle
+                    prop "heavy messages sent nicely" $
+                        withHeavyParcels $ plainDeliveryTest transport_ talkStyle
 
 prepareDeliveryTestState :: [Parcel] -> IO (TVar TestState)
 prepareDeliveryTestState expectedParcels =
@@ -40,10 +166,11 @@ prepareDeliveryTestState expectedParcels =
         expected .= S.fromList expectedParcels
 
 plainDeliveryTest
-    :: TalkStyle
+    :: NT.Transport
+    -> TalkStyle
     -> NonEmptyList Parcel
     -> Property
-plainDeliveryTest talkStyle neparcels = ioProperty $ do
+plainDeliveryTest transport_ talkStyle neparcels = ioProperty $ do
     let parcels = getNonEmpty neparcels
     testState <- prepareDeliveryTestState parcels
 
@@ -53,7 +180,7 @@ plainDeliveryTest talkStyle neparcels = ioProperty $ do
         listener = receiveAll talkStyle $
             \parcel -> modifyTestState testState $ expected %= sans parcel
 
-    deliveryTest testState [worker] [listener]
+    deliveryTest transport_ testState [worker] [listener]
 
 withHeavyParcels :: (NonEmptyList Parcel -> Property) -> NonEmptyList HeavyParcel -> Property
 withHeavyParcels testCase (NonEmpty megaParcels) = testCase (NonEmpty (getHeavyParcel <$> megaParcels))


### PR DESCRIPTION
The race was incredibly rare, probably never to be seen except on self-connections: it was possible to get the ACK before the handler/nonce was registered in the state.

Testing is improved: two sloppy new cases for self connections and peer data. Also updated the spec to use in-memory and TCP transports.