### PR TITLE
Update to LTS Haskell 8.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: lts-7.16
-compiler: ghc-8.0.2
+resolver: lts-8.2
 
 packages:
   - '.'
@@ -20,21 +19,14 @@ packages:
       commit: c6893b17531ed47838c8d8f0bf434cf0119b50df
     extra-dep: true
 
-extra-deps:
-  - network-transport-inmemory-0.5.2
-
 nix:
   enable: false
   packages: []
 
 extra-deps:
-  - serokell-util-0.1.3.2
+  - serokell-util-0.1.3.5
   - time-units-1.0.0
-  - pqueue-1.3.2
-  - aeson-extra-0.4.0.0
-  - data-msgpack-0.0.8
-  - recursion-schemes-5.0.1
-  - log-warper-0.4.1
+  - log-warper-0.4.4
   - universum-0.2.1
 
 flags: {}


### PR DESCRIPTION
So we don't have a mismatch between compiler and resolver anymore, which
made it difficult to install ghci and intero.

Also, dropped `extra-deps` that are in LTS 8.2, and updated `serokell-util`.