### PR TITLE
Update stack.yaml for nt-(tcp)(inmemory)

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -39,7 +39,7 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" "127.0.0.1" (show port)
+    Right transport_ <- TCP.createTransport "0.0.0.0" (show port) ((,) "127.0.0.1")
         TCP.defaultTCPParameters
     let transport = concrete transport_
 

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -58,7 +58,7 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" "127.0.0.1" "3432" TCP.defaultTCPParameters
+    Right transport_ <- TCP.createTransport "0.0.0.0" "3432" ((,) "127.0.0.1") TCP.defaultTCPParameters
     let transport = concrete transport_
 
     let prngNode = mkStdGen 0

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -111,7 +111,7 @@ main = runProduction $ do
     when (number > 99 || number < 1) $ error "Give a number in [1,99]"
 
     Right transport_ <- liftIO $
-        TCP.createTransport "0.0.0.0" "127.0.0.1" "10128" TCP.defaultTCPParameters
+        TCP.createTransport "0.0.0.0" "10128" ((,) "127.0.0.1") TCP.defaultTCPParameters
     let transport = concrete transport_
 
     liftIO . putStrLn $ "Spawning " ++ show number ++ " nodes"

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -79,7 +79,7 @@ main :: IO ()
 main = runProduction $ do
 
     Right transport_ <- liftIO $
-        TCP.createTransport "0.0.0.0" "127.0.0.1" "10128" TCP.defaultTCPParameters
+        TCP.createTransport "0.0.0.0" "10128" ((,) "127.0.0.1") TCP.defaultTCPParameters
     let transport = concrete transport_
 
     let prng1 = mkStdGen 0

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,16 +7,16 @@ packages:
       commit: 278171b8ab104c78aa95bcdd9b63c8ced4fb1ed2
     extra-dep: true
   - location:
-      git: https://github.com/avieth/network-transport-tcp
-      commit: 8fb61171a0f09e554c051ca112e3967cea6b7f69
-    extra-dep: true
-  - location:
       git: https://github.com/avieth/network-transport
       commit: f2321a103f53f51d36c99383132e3ffa3ef1c401
     extra-dep: true
   - location:
+      git: https://github.com/avieth/network-transport-tcp
+      commit: 1739cc6d5c73257201e5551088f4ba56d5ede15c
+    extra-dep: true
+  - location:
       git: https://github.com/avieth/network-transport-inmemory
-      commit: c6893b17531ed47838c8d8f0bf434cf0119b50df
+      commit: 5d8ff2b07b9df35cf61329a3d975e2c8cf95c12a
     extra-dep: true
 
 nix:

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -285,7 +285,7 @@ makeTCPTransport bind hostAddr port qdisc = do
             , TCP.tcpReuseClientAddr = True
             , TCP.tcpNewQDisc = qdisc
             }
-    choice <- TCP.createTransport bind hostAddr port tcpParams
+    choice <- TCP.createTransport bind port ((,) hostAddr) tcpParams
     case choice of
         Left err -> error (show err)
         Right transport -> return transport


### PR DESCRIPTION
A network-transport-tcp change for a separate bind address has
landed in master. The type of createTransport has changed: the third
argument takes the actual bound port and returns a host address and port
to use as the external address.