### PR TITLE
Fair QDisc can de-prioritize certain peers

### DIFF
--- a/src/Network/QDisc/Simulation.hs
+++ b/src/Network/QDisc/Simulation.hs
@@ -72,7 +72,7 @@ data QDiscChoice = Fair | OnePlace | Unbounded
 
 makeQDisc :: QDiscChoice -> IO (QDisc t)
 makeQDisc choice = case choice of
-    Fair -> fairQDisc
+    Fair -> fairQDisc (const (return Nothing))
     Unbounded -> simpleUnboundedQDisc
     OnePlace -> simpleOnePlaceQDisc
 

--- a/test/Test/NodeSpec.hs
+++ b/test/Test/NodeSpec.hs
@@ -47,7 +47,7 @@ spec :: Spec
 spec = describe "Node" $ do
 
     let tcpTransportOnePlace = runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10342" simpleOnePlaceQDisc
-    let tcpTransportFair = runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10343" fairQDisc
+    let tcpTransportFair = runIO $ makeTCPTransport "0.0.0.0" "127.0.0.1" "10343" (fairQDisc (const (return Nothing)))
     let memoryTransport = runIO $ makeInMemoryTransport
     let transports = [
               ("In-memory", memoryTransport)


### PR DESCRIPTION
We may want to use this in conjunction with some mutable blacklist
determined by metrics gathered by a node, so as to induce artificial
delays on certain peers deemed to be abusive.

@kantp This might be useful in your abuse tests, if we can come
up with a suitable delay for a peer based upon the node's metrics
(for instance, using this feature https://github.com/serokell/time-warp-nt/pull/27).