### PR TITLE
[Tw 127] remove compiler warnings

### DIFF
--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -24,7 +24,6 @@ import           Network.Discovery.Abstract
 import qualified Network.Discovery.Transport.Kademlia as K
 import           Network.Transport.Abstract           (Transport (..))
 import           Network.Transport.Concrete           (concrete)
-import           Network.Transport.Concrete.TCP       as TCP
 import qualified Network.Transport.TCP                as TCP
 import           Node
 import           Node.Message                         (BinaryP (..))
@@ -60,7 +59,7 @@ worker anId generator discovery = pingWorker generator
             peerSet <- knownPeers discovery
             liftIO . putStrLn $ show anId ++ " has peer set: " ++ show peerSet
             forM_ (S.toList peerSet) $ \addr -> withConnectionTo sendActions (NodeId addr) $
-                \peerData (cactions :: ConversationActions Void Pong Production) -> do
+                \_peerData (cactions :: ConversationActions Void Pong Production) -> do
                     received <- recv cactions
                     case received of
                         Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show addr

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -57,7 +57,7 @@ worker anId generator peerIds = pingWorker generator
                 us = fromMicroseconds i :: Microsecond
             delay us
             let pong :: NodeId -> Production BS.ByteString -> ConversationActions Ping Pong Production -> Production ()
-                pong peerId peerData cactions = do
+                pong peerId _peerData cactions = do
                     liftIO . putStrLn $ show anId ++ " sent PING to " ++ show peerId
                     received <- recv cactions
                     case received of
@@ -90,10 +90,10 @@ main = runProduction $ do
     liftIO . putStrLn $ "Starting nodes"
     node transport prng1 BinaryP (B8.pack "I am node 1") $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
-            setupMonitor 8000 runProduction node1
+            _ <- setupMonitor 8000 runProduction node1
             node transport prng2 BinaryP (B8.pack "I am node 2") $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
-                    setupMonitor 8001 runProduction node2
+                    _ <- setupMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1
                     tid2 <- fork $ worker (nodeId node2) prng4 [nodeId node1] sactions2
                     liftIO . putStrLn $ "Hit return to stop"

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -88,7 +88,7 @@ Library
 
   hs-source-dirs:       src
   default-language:     Haskell2010
-  ghc-options:          -Wall -fno-warn-orphans
+  ghc-options:          -Wall -fno-warn-orphans -Werror
   default-extensions:   DeriveDataTypeable
                         DeriveGeneric
                         GeneralizedNewtypeDeriving

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -36,7 +36,6 @@ import qualified System.Metrics.Gauge     as EKG.Gauge
 import qualified System.Metrics.Counter   as EKG.Counter
 import           Serokell.Util.Concurrent as Serokell
 import           Universum                (MonadFail (..))
-import qualified Data.Sequence            as Seq
 
 newtype Production t = Production
     { runProduction :: IO t
@@ -142,7 +141,7 @@ instance Mockable Bracket Production where
     liftMockable (BracketWithException acquire release act) = Production $ mask $ \restore -> do
         a <- runProduction acquire
         r <- restore (runProduction (act a)) `catch` \e -> do
-                 runProduction (release a (Just e))
+                 _ <- runProduction (release a (Just e))
                  Exception.throwIO e
         _ <- runProduction (release a Nothing)
         return r

--- a/src/Network/Transport/Concrete/TCP.hs
+++ b/src/Network/Transport/Concrete/TCP.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Network.Transport.Concrete.TCP (

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -397,7 +397,7 @@ stAddHandler !provenance !statistics = case provenance of
     -- TODO: generalize this computation so we can use the same thing for
     -- both local and remote. It's a copy/paste job right now swapping local
     -- for remote.
-    Local _ _ -> do
+    Local !_peer _ -> do
         (!peerStatistics, !isNewPeer) <- pstAddHandler provenance (stPeerStatistics statistics)
         when isNewPeer $ Metrics.incGauge (stPeers statistics)
         Metrics.incGauge (stRunningHandlersLocal statistics)
@@ -413,7 +413,7 @@ stAddHandler !provenance !statistics = case provenance of
             , stRunningHandlersLocalAverage = runningHandlersLocalAverage
             }
 
-    Remote _ _ _ -> do
+    Remote !_peer _ _ -> do
         (!peerStatistics, !isNewPeer) <- pstAddHandler provenance (stPeerStatistics statistics)
         when isNewPeer $ Metrics.incGauge (stPeers statistics)
         Metrics.incGauge (stRunningHandlersRemote statistics)
@@ -461,7 +461,7 @@ stRemoveHandler !provenance !elapsed !outcome !statistics = case provenance of
     -- TODO: generalize this computation so we can use the same thing for
     -- both local and remote. It's a copy/paste job right now swapping local
     -- for remote.
-    Local _ _ -> do
+    Local !_peer _ -> do
         (!peerStatistics, !isEndedPeer) <- pstRemoveHandler provenance (stPeerStatistics statistics)
         when isEndedPeer $ Metrics.decGauge (stPeers statistics)
         Metrics.decGauge (stRunningHandlersLocal statistics)
@@ -478,7 +478,7 @@ stRemoveHandler !provenance !elapsed !outcome !statistics = case provenance of
             , stRunningHandlersLocalAverage = runningHandlersLocalAverage
             }
 
-    Remote _ _ _ -> do
+    Remote !_peer _ _ -> do
         (!peerStatistics, !isEndedPeer) <- pstRemoveHandler provenance (stPeerStatistics statistics)
         when isEndedPeer $ Metrics.decGauge (stPeers statistics)
         Metrics.decGauge (stRunningHandlersRemote statistics)

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -709,8 +709,8 @@ nodeDispatcher node handlerIn handlerInOut =
       event <- NT.receive endpoint
       case event of
 
-          NT.ConnectionOpened connid reliability peer ->
-              connectionOpened state connid reliability peer >>= loop
+          NT.ConnectionOpened connid _reliability peer ->
+              connectionOpened state connid peer >>= loop
 
           NT.Received connid bytes -> received state connid bytes >>= loop
 
@@ -774,10 +774,9 @@ nodeDispatcher node handlerIn handlerInOut =
     connectionOpened
         :: DispatcherState peerData m
         -> NT.ConnectionId
-        -> NT.Reliability -- TODO: this is not actually used. If this is intentional, we should remove the parameter.
         -> NT.EndPointAddress
         -> m (DispatcherState peerData m)
-    connectionOpened state connid _reliability peer = case Map.lookup connid (dsConnections state) of
+    connectionOpened state connid peer = case Map.lookup connid (dsConnections state) of
 
         Just (peer', _) -> do
             logWarning $ sformat ("ignoring duplicate connection " % shown % shown % shown) peer peer' connid

--- a/src/Node/Message.hs
+++ b/src/Node/Message.hs
@@ -22,7 +22,6 @@ module Node.Message
     , BinaryP (..)
     ) where
 
-import           Control.Monad                 (unless)
 import qualified Data.Binary                   as Bin
 import qualified Data.Binary.Get               as Bin
 import qualified Data.Binary.Put               as Bin
@@ -32,19 +31,13 @@ import qualified Data.ByteString.Lazy          as LBS
 import           Data.Data                     (Data, dataTypeName, dataTypeOf)
 import           Data.Hashable                 (Hashable)
 import           Data.Proxy                    (Proxy (..), asProxyTypeOf)
-import           Data.String                   (IsString)
-import           Data.String                   (fromString)
+import           Data.String                   (IsString, fromString)
 import qualified Data.Text                     as T
 import           Data.Text.Buildable           (Buildable)
 import qualified Data.Text.Buildable           as B
 import qualified Formatting                    as F
 import           GHC.Generics                  (Generic)
 import           Serokell.Util.Base16          (base16F)
-
-import           Mockable.Channel              (Channel, ChannelT, readChannel,
-                                                unGetChannel)
-import           Mockable.Class                (Mockable)
-
 
 -- * Message name
 

--- a/src/Node/Util/Monitor.hs
+++ b/src/Node/Util/Monitor.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GADTs #-}


### PR DESCRIPTION
This reduces the noise at compile time, making it easier to spot warnings that might be important.

Also, replaced some incomplete pattern matches with Exceptions.