### PR TITLE
[TW-114] timeout waiting for ACK

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -22,7 +22,7 @@ import           Bench.Network.Commons      (MeasureEvent (..), Ping (..), Pong 
 import qualified Network.Transport.TCP      as TCP
 import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
-                                             sendTo)
+                                             sendTo, defaultNodeEnvironment)
 import           Node.Message               (BinaryP (..))
 import           ReceiverOptions            (Args (..), argsParser)
 
@@ -46,7 +46,7 @@ main = do
     let prng = mkStdGen 0
 
     runProduction $ usingLoggerName "receiver" $ do
-        node transport prng BinaryP () $ \_ ->
+        node transport prng BinaryP () defaultNodeEnvironment $ \_ ->
             NodeAction [pingListener noPong] $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -26,7 +26,8 @@ import           Mockable                   (fork, realTime, delay, Production, 
 import qualified Network.Transport.Abstract as NT
 import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
-                                             nodeEndPoint, sendTo, Node(..))
+                                             nodeEndPoint, sendTo, Node(..),
+                                             defaultNodeEnvironment)
 import           Node.Internal              (NodeId (..))
 import           Node.Message               (BinaryP (..))
 
@@ -75,7 +76,7 @@ main = do
             let pingWorkers = liftA2 (pingSender prngWork payloadBound startTime msgRate)
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
-            node transport prngNode BinaryP () $ \node' ->
+            node transport prngNode BinaryP () defaultNodeEnvironment $ \node' ->
                 NodeAction [pongListener] $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -91,7 +91,7 @@ makeNode transport i = do
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    fork $ node transport prng1 BinaryP (B8.pack "my peer data!") $ \node' ->
+    fork $ node transport prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
             discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node')

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -88,10 +88,10 @@ main = runProduction $ do
     let prng4 = mkStdGen 3
 
     liftIO . putStrLn $ "Starting nodes"
-    node transport prng1 BinaryP (B8.pack "I am node 1") $ \node1 ->
+    node transport prng1 BinaryP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
             _ <- setupMonitor 8000 runProduction node1
-            node transport prng2 BinaryP (B8.pack "I am node 2") $ \node2 ->
+            node transport prng2 BinaryP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
                     _ <- setupMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1

--- a/src/Mockable/Production.hs
+++ b/src/Mockable/Production.hs
@@ -52,9 +52,9 @@ type instance ThreadId Production = Conc.ThreadId
 instance Mockable Fork Production where
     {-# INLINABLE liftMockable #-}
     {-# SPECIALIZE INLINE liftMockable :: Fork Production t -> Production t #-}
-    liftMockable (Fork m)         = Production $ Conc.forkIO (runProduction m)
-    liftMockable (MyThreadId)     = Production $ Conc.myThreadId
-    liftMockable (KillThread tid) = Production $ Conc.killThread tid
+    liftMockable (Fork m)        = Production $ Conc.forkIO (runProduction m)
+    liftMockable (MyThreadId)    = Production $ Conc.myThreadId
+    liftMockable (ThrowTo tid e) = Production $ Conc.throwTo tid e
 
 instance Mockable Delay Production where
     {-# INLINABLE liftMockable #-}
@@ -78,12 +78,12 @@ type instance Promise Production = Conc.Async
 instance Mockable Async Production where
     {-# INLINABLE liftMockable #-}
     {-# SPECIALIZE INLINE liftMockable :: Async Production t -> Production t #-}
-    liftMockable (Async m)          = Production $ Conc.async (runProduction m)
-    liftMockable (WithAsync m k)    = Production $ Conc.withAsync (runProduction m) (runProduction . k)
-    liftMockable (Wait promise)     = Production $ Conc.wait promise
-    liftMockable (WaitAny promises) = Production $ Conc.waitAny promises
-    liftMockable (Cancel promise)   = Production $ Conc.cancel promise
-    liftMockable (AsyncThreadId p)  = Production $ return (Conc.asyncThreadId p)
+    liftMockable (Async m)              = Production $ Conc.async (runProduction m)
+    liftMockable (WithAsync m k)        = Production $ Conc.withAsync (runProduction m) (runProduction . k)
+    liftMockable (Wait promise)         = Production $ Conc.wait promise
+    liftMockable (WaitAny promises)     = Production $ Conc.waitAny promises
+    liftMockable (CancelWith promise e) = Production $ Conc.cancelWith promise e
+    liftMockable (AsyncThreadId p)      = Production $ return (Conc.asyncThreadId p)
 
 instance Mockable Concurrently Production where
     {-# INLINABLE liftMockable #-}

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -77,7 +77,7 @@ import           Test.QuickCheck.Property    (Testable (..), failed, reason, suc
 import           Node                        (ConversationActions (..), Listener,
                                               ListenerAction (..), Message (..),
                                               NodeAction (..), NodeId, SendActions (..),
-                                              Worker, node, nodeId)
+                                              Worker, node, nodeId, defaultNodeEnvironment)
 import           Node.Message                (BinaryP (..))
 
 -- | Run a computation, but kill it if it takes more than a given number of
@@ -308,7 +308,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
     clientFinished <- newSharedExclusive
     serverFinished <- newSharedExclusive
 
-    let server = node transport prng1 BinaryP () $ \serverNode -> do
+    let server = node transport prng1 BinaryP () defaultNodeEnvironment $ \serverNode -> do
             NodeAction listeners $ \_ -> do
                 -- Give our address to the client.
                 putSharedExclusive serverAddressVar (nodeId serverNode)
@@ -319,7 +319,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
                 -- Allow the client to stop.
                 putSharedExclusive serverFinished ()
 
-    let client = node transport prng2 BinaryP () $ \clientNode ->
+    let client = node transport prng2 BinaryP () defaultNodeEnvironment $ \clientNode ->
             NodeAction [] $ \sendActions -> do
                 serverAddress <- takeSharedExclusive serverAddressVar
                 void . forConcurrently workers $ \worker ->


### PR DESCRIPTION
A programmable timeout in microseconds is given when a node is created. If a bidirectional connection does not hear an ACK before this time then it's killed with a `Timeout` exception. A test case is included.