### PR TITLE
node/startNode don't take a Transport

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -22,7 +22,8 @@ import           Bench.Network.Commons      (MeasureEvent (..), Ping (..), Pong 
 import qualified Network.Transport.TCP      as TCP
 import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
-                                             sendTo, defaultNodeEnvironment)
+                                             sendTo, defaultNodeEnvironment,
+                                             simpleNodeEndPoint)
 import           Node.Message               (BinaryP (..))
 import           ReceiverOptions            (Args (..), argsParser)
 
@@ -46,7 +47,7 @@ main = do
     let prng = mkStdGen 0
 
     runProduction $ usingLoggerName "receiver" $ do
-        node transport prng BinaryP () defaultNodeEnvironment $ \_ ->
+        node (simpleNodeEndPoint transport) prng BinaryP () defaultNodeEnvironment $ \_ ->
             NodeAction [pingListener noPong] $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -27,7 +27,7 @@ import qualified Network.Transport.Abstract as NT
 import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
                                              nodeEndPoint, sendTo, Node(..),
-                                             defaultNodeEnvironment)
+                                             defaultNodeEnvironment, simpleNodeEndPoint)
 import           Node.Internal              (NodeId (..))
 import           Node.Message               (BinaryP (..))
 
@@ -76,7 +76,7 @@ main = do
             let pingWorkers = liftA2 (pingSender prngWork payloadBound startTime msgRate)
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
-            node transport prngNode BinaryP () defaultNodeEnvironment $ \node' ->
+            node (simpleNodeEndPoint transport) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
                 NodeAction [pongListener] $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -93,7 +93,7 @@ makeNode transport i = do
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    fork $ node transport prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
+    fork $ node (simpleNodeEndPoint transport) prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
             discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node')

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -90,10 +90,10 @@ main = runProduction $ do
     let prng4 = mkStdGen 3
 
     liftIO . putStrLn $ "Starting nodes"
-    node transport prng1 BinaryP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
+    node (simpleNodeEndPoint transport) prng1 BinaryP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
             _ <- setupMonitor 8000 runProduction node1
-            node transport prng2 BinaryP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
+            node (simpleNodeEndPoint transport) prng2 BinaryP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
                     _ <- setupMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -21,6 +21,7 @@ module Node.Internal (
     NodeEnvironment(..),
     defaultNodeEnvironment,
     NodeEndPoint(..),
+    simpleNodeEndPoint,
     NodeState(..),
     nodeId,
     nodeEndPointAddress,
@@ -545,10 +546,21 @@ stRemoveHandler !provenance !elapsed !outcome !statistics = case provenance of
             avg' = avg - (1 / fromIntegral npeers)
             avg2' = avg - (fromIntegral (2 * nhandlers + 1) / fromIntegral npeers)
 
--- | TODO document.
+-- | How to create and close an 'EndPoint'.
+--   See 'simpleNodeEndPoint' for a very obvious example.
+--   More complicated things are possible, for instance using concrete
+--   transport specific features.
 data NodeEndPoint m = NodeEndPoint {
       newNodeEndPoint :: m (Either (NT.TransportError NT.NewEndPointErrorCode) (NT.EndPoint m))
     , closeNodeEndPoint :: NT.EndPoint m -> m ()
+    }
+
+-- | A 'NodeEndPoint' which uses the typical network-transport 'newEndPoint'
+--   and 'closeEndPoint'.
+simpleNodeEndPoint :: NT.Transport m -> NodeEndPoint m
+simpleNodeEndPoint transport = NodeEndPoint {
+      newNodeEndPoint = NT.newEndPoint transport
+    , closeNodeEndPoint = NT.closeEndPoint
     }
 
 -- | Bring up a 'Node' using a network transport.

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -77,7 +77,8 @@ import           Test.QuickCheck.Property    (Testable (..), failed, reason, suc
 import           Node                        (ConversationActions (..), Listener,
                                               ListenerAction (..), Message (..),
                                               NodeAction (..), NodeId, SendActions (..),
-                                              Worker, node, nodeId, defaultNodeEnvironment)
+                                              Worker, node, nodeId, defaultNodeEnvironment,
+                                              simpleNodeEndPoint)
 import           Node.Message                (BinaryP (..))
 
 -- | Run a computation, but kill it if it takes more than a given number of
@@ -308,7 +309,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
     clientFinished <- newSharedExclusive
     serverFinished <- newSharedExclusive
 
-    let server = node transport prng1 BinaryP () defaultNodeEnvironment $ \serverNode -> do
+    let server = node (simpleNodeEndPoint transport) prng1 BinaryP () defaultNodeEnvironment $ \serverNode -> do
             NodeAction listeners $ \_ -> do
                 -- Give our address to the client.
                 putSharedExclusive serverAddressVar (nodeId serverNode)
@@ -319,7 +320,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
                 -- Allow the client to stop.
                 putSharedExclusive serverFinished ()
 
-    let client = node transport prng2 BinaryP () defaultNodeEnvironment $ \clientNode ->
+    let client = node (simpleNodeEndPoint transport) prng2 BinaryP () defaultNodeEnvironment $ \clientNode ->
             NodeAction [] $ \sendActions -> do
                 serverAddress <- takeSharedExclusive serverAddressVar
                 void . forConcurrently workers $ \worker ->


### PR DESCRIPTION
Instead, they just need a way to create and to close an EndPoint. For
the low-level startNode, the whole Node is in scope. For the high level
node, only the mutable cell of the node's state is in scope.

This allows us to use non-standard features of a transport, for instance
the TCP transport's QDisc, to create an EndPoint to be used by the node.
There is a patch for network-transport-tcp which allows the choice of a
particular QDisc for each new EndPoint, but it can only be done through
the TCP internals as the network-transport newEndPoint type doesn't
permit such a thing. With the changes here, it's possible to use the TCP
internals to create a special QDisc with the node's state in scope,
thereby using traffic metrics to control queueing.

Relevant network-transport-tcp change is [here](https://github.com/haskell-distributed/network-transport-tcp/pull/58)