### PR TITLE
Use nt-tcp NAT, hoist functions for abstract transport

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -40,7 +40,7 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" (show port) ((,) "127.0.0.1")
+    Right transport_ <- TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" (show port))
         TCP.defaultTCPParameters
     let transport = concrete transport_
 

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -7,34 +7,35 @@
 
 module Main where
 
-import           Control.Applicative        (empty, liftA2)
-import           Control.Lens               (makeLenses, (+=))
-import           Control.Monad              (forM, forM_)
-import           Control.Monad.Random       (evalRandT, getRandomR)
-import           Control.Monad.State        (evalStateT, get, put)
-import           Control.Monad.Trans        (MonadIO (liftIO), lift)
+import           Control.Applicative            (empty, liftA2)
+import           Control.Lens                   (makeLenses, (+=))
+import           Control.Monad                  (forM, forM_)
+import           Control.Monad.Random           (evalRandT, getRandomR)
+import           Control.Monad.State            (evalStateT, get, put)
+import           Control.Monad.Trans            (MonadIO (liftIO), lift)
 
-import           Data.Time.Units            (Microsecond, Second, convertUnit)
-import           GHC.IO.Encoding            (setLocaleEncoding, utf8)
-import qualified Network.Transport.TCP      as TCP
-import           Options.Applicative.Simple (simpleOptions)
-import           Serokell.Util.Concurrent   (threadDelay)
-import           System.Random              (mkStdGen)
-import           System.Wlog                (usingLoggerName, LoggerNameBox)
+import           Data.Time.Units                (Microsecond, Second, convertUnit)
+import           GHC.IO.Encoding                (setLocaleEncoding, utf8)
+import qualified Network.Transport.TCP          as TCP
+import qualified Network.Transport.TCP.Internal as TCP (encodeEndPointAddress)
+import           Options.Applicative.Simple     (simpleOptions)
+import           Serokell.Util.Concurrent       (threadDelay)
+import           System.Random                  (mkStdGen)
+import           System.Wlog                    (usingLoggerName, LoggerNameBox)
 
-import           Mockable                   (fork, realTime, delay, Production, runProduction)
-import qualified Network.Transport.Abstract as NT
-import           Network.Transport.Concrete (concrete)
-import           Node                       (ListenerAction (..), NodeAction (..), node,
-                                             nodeEndPoint, sendTo, Node(..),
-                                             defaultNodeEnvironment, simpleNodeEndPoint)
-import           Node.Internal              (NodeId (..))
-import           Node.Message               (BinaryP (..))
+import           Mockable                       (fork, realTime, delay, Production, runProduction)
+import qualified Network.Transport.Abstract     as NT
+import           Network.Transport.Concrete     (concrete)
+import           Node                           (ListenerAction (..), NodeAction (..), node,
+                                                 nodeEndPoint, sendTo, Node(..),
+                                                 defaultNodeEnvironment, simpleNodeEndPoint)
+import           Node.Internal                  (NodeId (..))
+import           Node.Message                   (BinaryP (..))
 
 
-import           Bench.Network.Commons      (MeasureEvent (..), Payload (..), Ping (..),
-                                             Pong (..), loadLogConfig, logMeasure)
-import           SenderOptions              (Args (..), argsParser)
+import           Bench.Network.Commons          (MeasureEvent (..), Payload (..), Ping (..),
+                                                 Pong (..), loadLogConfig, logMeasure)
+import           SenderOptions                  (Args (..), argsParser)
 
 data PingState = PingState
     { _lastResetMcs    :: !Microsecond

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -59,7 +59,7 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" "3432" ((,) "127.0.0.1") TCP.defaultTCPParameters
+    Right transport_ <- TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" "3432") TCP.defaultTCPParameters
     let transport = concrete transport_
 
     let prngNode = mkStdGen 0

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -111,8 +111,9 @@ main = runProduction $ do
 
     when (number > 99 || number < 1) $ error "Give a number in [1,99]"
 
+    let params = TCP.defaultTCPParameters { TCP.tcpCheckPeerHost = True }
     Right transport_ <- liftIO $
-        TCP.createTransport "0.0.0.0" "10128" ((,) "127.0.0.1") TCP.defaultTCPParameters
+        TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" "10128") params
     let transport = concrete transport_
 
     liftIO . putStrLn $ "Spawning " ++ show number ++ " nodes"

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -80,8 +80,9 @@ listeners anId = [pongListener]
 main :: IO ()
 main = runProduction $ do
 
+    let params = TCP.defaultTCPParameters { TCP.tcpCheckPeerHost = True }
     Right transport_ <- liftIO $
-        TCP.createTransport "0.0.0.0" "10128" ((,) "127.0.0.1") TCP.defaultTCPParameters
+        TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" "10128") params
     let transport = concrete transport_
 
     let prng1 = mkStdGen 0

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -72,7 +72,7 @@ kademliaDiscovery configuration initialPeer myAddress = do
         port = fromIntegral (kademliaPort configuration)
     -- A Kademlia instance to do the DHT magic.
     kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-        <- liftIO $ K.create port kid
+        <- liftIO $ K.create "127.0.0.1" port kid
     -- A TVar to cache the set of known peers at the last use of 'discoverPeers'
     peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
         <- liftIO . TVar.newTVarIO $ M.empty

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -144,7 +144,7 @@ data SendActions packing peerData m = SendActions {
 
 data ConversationActions body rcv m = ConversationActions {
        -- | Send a message within the context of this conversation
-       send     :: body -> m ()
+       send :: body -> m ()
 
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -918,7 +918,7 @@ nodeDispatcher node handlerIn handlerInOut =
                     -- Protocol error. We got data from some other lightweight
                     -- connection before the peer data was parsed.
                     False -> do
-                        logWarning $ sformat ("peer-data protocol error")
+                        logWarning $ sformat ("peer data protocol error from " % shown) peer
                         return state
 
                     True -> case decoderContinuation (Just (BS.concat chunks)) of

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
   - '.'
   - location:
       git: https://github.com/serokell/kademlia.git
-      commit: 278171b8ab104c78aa95bcdd9b63c8ced4fb1ed2
+      commit: 21df94f41008f82ee023e8e0324c7e4a82c4fef2
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-tcp
-      commit: 1739cc6d5c73257201e5551088f4ba56d5ede15c
+      commit: eb1ed2fe4d4419c860ce060cb1091f7c8959134f
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-inmemory

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -286,7 +286,7 @@ makeTCPTransport bind hostAddr port qdisc = do
             , TCP.tcpReuseClientAddr = True
             , TCP.tcpNewQDisc = qdisc
             }
-    choice <- TCP.createTransport bind port ((,) hostAddr) tcpParams
+    choice <- TCP.createTransport (TCP.Addressable (TCP.TCPAddrInfo bind port ((,) hostAddr))) tcpParams
     case choice of
         Left err -> error (show err)
         Right transport -> return transport


### PR DESCRIPTION
In one application it was necessary to change the monad over which a transport operates. `hoistTransport` implements this.