### PR TITLE
NAT support with special case for 0.0.0.0, 127.0.0.1

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -40,7 +40,7 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" (show port) ((,) "127.0.0.1")
+    Right transport_ <- TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" (show port))
         TCP.defaultTCPParameters
     let transport = concrete transport_
 

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -7,34 +7,35 @@
 
 module Main where
 
-import           Control.Applicative        (empty, liftA2)
-import           Control.Lens               (makeLenses, (+=))
-import           Control.Monad              (forM, forM_)
-import           Control.Monad.Random       (evalRandT, getRandomR)
-import           Control.Monad.State        (evalStateT, get, put)
-import           Control.Monad.Trans        (MonadIO (liftIO), lift)
+import           Control.Applicative            (empty, liftA2)
+import           Control.Lens                   (makeLenses, (+=))
+import           Control.Monad                  (forM, forM_)
+import           Control.Monad.Random           (evalRandT, getRandomR)
+import           Control.Monad.State            (evalStateT, get, put)
+import           Control.Monad.Trans            (MonadIO (liftIO), lift)
 
-import           Data.Time.Units            (Microsecond, Second, convertUnit)
-import           GHC.IO.Encoding            (setLocaleEncoding, utf8)
-import qualified Network.Transport.TCP      as TCP
-import           Options.Applicative.Simple (simpleOptions)
-import           Serokell.Util.Concurrent   (threadDelay)
-import           System.Random              (mkStdGen)
-import           System.Wlog                (usingLoggerName, LoggerNameBox)
+import           Data.Time.Units                (Microsecond, Second, convertUnit)
+import           GHC.IO.Encoding                (setLocaleEncoding, utf8)
+import qualified Network.Transport.TCP          as TCP
+import qualified Network.Transport.TCP.Internal as TCP (encodeEndPointAddress)
+import           Options.Applicative.Simple     (simpleOptions)
+import           Serokell.Util.Concurrent       (threadDelay)
+import           System.Random                  (mkStdGen)
+import           System.Wlog                    (usingLoggerName, LoggerNameBox)
 
-import           Mockable                   (fork, realTime, delay, Production, runProduction)
-import qualified Network.Transport.Abstract as NT
-import           Network.Transport.Concrete (concrete)
-import           Node                       (ListenerAction (..), NodeAction (..), node,
-                                             nodeEndPoint, sendTo, Node(..),
-                                             defaultNodeEnvironment, simpleNodeEndPoint)
-import           Node.Internal              (NodeId (..))
-import           Node.Message               (BinaryP (..))
+import           Mockable                       (fork, realTime, delay, Production, runProduction)
+import qualified Network.Transport.Abstract     as NT
+import           Network.Transport.Concrete     (concrete)
+import           Node                           (ListenerAction (..), NodeAction (..), node,
+                                                 nodeEndPoint, sendTo, Node(..),
+                                                 defaultNodeEnvironment, simpleNodeEndPoint)
+import           Node.Internal                  (NodeId (..))
+import           Node.Message                   (BinaryP (..))
 
 
-import           Bench.Network.Commons      (MeasureEvent (..), Payload (..), Ping (..),
-                                             Pong (..), loadLogConfig, logMeasure)
-import           SenderOptions              (Args (..), argsParser)
+import           Bench.Network.Commons          (MeasureEvent (..), Payload (..), Ping (..),
+                                                 Pong (..), loadLogConfig, logMeasure)
+import           SenderOptions                  (Args (..), argsParser)
 
 data PingState = PingState
     { _lastResetMcs    :: !Microsecond

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -59,7 +59,7 @@ main = do
     loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
-    Right transport_ <- TCP.createTransport "0.0.0.0" "3432" ((,) "127.0.0.1") TCP.defaultTCPParameters
+    Right transport_ <- TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" "3432") TCP.defaultTCPParameters
     let transport = concrete transport_
 
     let prngNode = mkStdGen 0

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -89,7 +89,7 @@ makeNode transport i = do
             -- its initial peer appears to be down.
             then K.Node (K.Peer host (fromIntegral port)) anId
             else K.Node (K.Peer host (fromIntegral (port - 1))) (makeId (i - 1))
-    let kademliaConfig = K.KademliaConfiguration (fromIntegral port) anId
+    let kademliaConfig = K.KademliaConfiguration host (fromIntegral port) anId
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -111,8 +111,9 @@ main = runProduction $ do
 
     when (number > 99 || number < 1) $ error "Give a number in [1,99]"
 
+    let params = TCP.defaultTCPParameters { TCP.tcpCheckPeerHost = True }
     Right transport_ <- liftIO $
-        TCP.createTransport "0.0.0.0" "10128" ((,) "127.0.0.1") TCP.defaultTCPParameters
+        TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" "10128") params
     let transport = concrete transport_
 
     liftIO . putStrLn $ "Spawning " ++ show number ++ " nodes"

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -80,8 +80,9 @@ listeners anId = [pongListener]
 main :: IO ()
 main = runProduction $ do
 
+    let params = TCP.defaultTCPParameters { TCP.tcpCheckPeerHost = True }
     Right transport_ <- liftIO $
-        TCP.createTransport "0.0.0.0" "10128" ((,) "127.0.0.1") TCP.defaultTCPParameters
+        TCP.createTransport (TCP.defaultTCPAddr "127.0.0.1" "10128") params
     let transport = concrete transport_
 
     let prng1 = mkStdGen 0

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -38,7 +38,8 @@ instance Binary i => K.Serialize (KSerialize i) where
 
 -- | Configuration for a Kademlia node.
 data KademliaConfiguration i = KademliaConfiguration {
-      kademliaPort :: Word16
+      kademliaHost :: String
+    , kademliaPort :: Word16
       -- ^ The port on which to run the server (it's UDP)
     , kademliaId   :: i
       -- ^ Some value to use as the identifier for this node. To use it, it must
@@ -72,7 +73,7 @@ kademliaDiscovery configuration initialPeer myAddress = do
         port = fromIntegral (kademliaPort configuration)
     -- A Kademlia instance to do the DHT magic.
     kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-        <- liftIO $ K.create port kid
+        <- liftIO $ K.create (kademliaHost configuration) port kid
     -- A TVar to cache the set of known peers at the last use of 'discoverPeers'
     peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
         <- liftIO . TVar.newTVarIO $ M.empty

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -144,7 +144,7 @@ data SendActions packing peerData m = SendActions {
 
 data ConversationActions body rcv m = ConversationActions {
        -- | Send a message within the context of this conversation
-       send     :: body -> m ()
+       send :: body -> m ()
 
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,8 @@ resolver: lts-8.2
 packages:
   - '.'
   - location:
-      git: https://github.com/serokell/kademlia.git
-      commit: 278171b8ab104c78aa95bcdd9b63c8ced4fb1ed2
+      git: https://github.com/avieth/kademlia.git
+      commit: 90c94245d86e4e6008734ab1c7d1e070a75e4834
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-tcp
-      commit: eb1ed2fe4d4419c860ce060cb1091f7c8959134f
+      commit: ca42a954a15792f5ea8dc203e56fac8175b99c33
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-inmemory

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-tcp
-      commit: 1739cc6d5c73257201e5551088f4ba56d5ede15c
+      commit: eb1ed2fe4d4419c860ce060cb1091f7c8959134f
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-inmemory

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -286,7 +286,7 @@ makeTCPTransport bind hostAddr port qdisc = do
             , TCP.tcpReuseClientAddr = True
             , TCP.tcpNewQDisc = qdisc
             }
-    choice <- TCP.createTransport bind port ((,) hostAddr) tcpParams
+    choice <- TCP.createTransport (TCP.Addressable (TCP.TCPAddrInfo bind port ((,) hostAddr))) tcpParams
     case choice of
         Left err -> error (show err)
         Right transport -> return transport


### PR DESCRIPTION
Emergency patch to handle NAT without forcing users to upgrade their clients.

The meat is in the network-transport-tcp revision bump avieth/csl_2_nat https://github.com/avieth/network-transport-tcp/tree/avieth/csl_2_nat