### PR TITLE
[TW-138] provide peer data on all interactions

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -22,7 +22,7 @@ import           Bench.Network.Commons      (MeasureEvent (..), Ping (..), Pong 
 import qualified Network.Transport.TCP      as TCP
 import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
-                                             sendTo, defaultNodeEnvironment,
+                                             defaultNodeEnvironment, ConversationActions (..),
                                              simpleNodeEndPoint)
 import           Node.Message               (BinaryP (..))
 import           ReceiverOptions            (Args (..), argsParser)
@@ -52,10 +52,9 @@ main = do
                 threadDelay (fromIntegral duration :: Second)
   where
     pingListener noPong =
-        -- TODO: `ListenerActionConversation` is not supported in such context
-        -- why? how should it be used?
-        ListenerActionOneMsg $ \_ peerId sendActions (Ping mid payload) -> do
+        ListenerActionConversation $ \_ peerId cactions -> do
+            Just (Ping mid payload) <- recv cactions
             logMeasure PingReceived mid payload
             unless noPong $ do
                 logMeasure PongSent mid payload
-                sendTo sendActions peerId $ Pong mid payload
+                send cactions (Pong mid payload)

--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -52,7 +52,7 @@ main = do
                 threadDelay (fromIntegral duration :: Second)
   where
     pingListener noPong =
-        ListenerActionConversation $ \_ peerId cactions -> do
+        ListenerActionConversation $ \_ _ cactions -> do
             Just (Ping mid payload) <- recv cactions
             logMeasure PingReceived mid payload
             unless noPong $ do

--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -48,7 +48,7 @@ main = do
 
     runProduction $ usingLoggerName "receiver" $ do
         node (simpleNodeEndPoint transport) prng BinaryP () defaultNodeEnvironment $ \_ ->
-            NodeAction [pingListener noPong] $ \_ -> do
+            NodeAction (const [pingListener noPong]) $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where
     pingListener noPong =

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -79,7 +79,7 @@ main = do
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
             node (simpleNodeEndPoint transport) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
-                NodeAction [] $ \sactions -> do
+                NodeAction (const []) $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)
                     delay (fromIntegral duration :: Second)

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -27,8 +27,8 @@ import           Mockable                       (Production, delay, fork, realTi
                                                  runProduction)
 import qualified Network.Transport.Abstract     as NT
 import           Network.Transport.Concrete     (concrete)
-import           Node                           (ListenerAction (..), NodeAction (..), node,
-                                                 nodeEndPoint, Node(..), SendActions (..),
+import           Node                           (NodeAction (..), node, Node(Node),
+                                                 nodeEndPoint, SendActions (..),
                                                  Conversation (..), ConversationActions (..),
                                                  defaultNodeEnvironment, simpleNodeEndPoint,
                                                  noReceiveDelay)
@@ -82,7 +82,7 @@ main = do
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
             node (simpleNodeEndPoint transport) (const noReceiveDelay) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
-                NodeAction (const [pongListener]) $ \sactions -> do
+                NodeAction (const []) $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)
                     delay (fromIntegral duration :: Second)
@@ -101,7 +101,7 @@ main = do
             lift . lift $ withConnectionTo sendActions peerId $
                 \_ -> Conversation $ \cactions -> do
                     send cactions (Ping sMsgId payload)
-                    Just (Pong sMsgId' payload') <- recv cactions
+                    Just (Pong _ _) <- recv cactions
                     return ()
 
             PingState{..}    <- get

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -68,8 +68,8 @@ worker anId generator discovery = pingWorker generator
                         Nothing -> error "Unexpected end of input"
             loop gen'
 
-listeners :: NodeId -> [Listener Packing BS.ByteString Production]
-listeners anId = [pongListener]
+listeners :: NodeId -> BS.ByteString -> [Listener Packing BS.ByteString Production]
+listeners anId = const [pongListener]
     where
     pongListener :: ListenerAction Packing BS.ByteString Production
     pongListener = ListenerActionConversation $ \peerData peerId (cactions :: ConversationActions Pong Void Production) -> do

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -61,7 +61,7 @@ worker anId generator discovery = pingWorker generator
             peerSet <- knownPeers discovery
             liftIO . putStrLn $ show anId ++ " has peer set: " ++ show peerSet
             forM_ (S.toList peerSet) $ \addr -> withConnectionTo sendActions (NodeId addr) $
-                \_peerData (cactions :: ConversationActions Void Pong Production) -> do
+                \_peerData -> Conversation $ \(cactions :: ConversationActions Void Pong Production) -> do
                     received <- recv cactions
                     case received of
                         Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show addr

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -69,8 +69,8 @@ worker anId generator peerIds = pingWorker generator
                 \peerData -> Conversation (pong peerId)
             loop gen'
 
-listeners :: NodeId -> [Listener Packing BS.ByteString Production]
-listeners anId = [pongListener]
+listeners :: NodeId -> BS.ByteString -> [Listener Packing BS.ByteString Production]
+listeners anId = const [pongListener]
     where
     pongListener :: ListenerAction Packing BS.ByteString Production
     pongListener = ListenerActionConversation $ \peerData peerId (cactions :: ConversationActions Pong Ping Production) -> do

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -58,14 +58,15 @@ worker anId generator peerIds = pingWorker generator
             let (i, gen') = randomR (0,1000000) g
                 us = fromMicroseconds i :: Microsecond
             delay us
-            let pong :: NodeId -> Production BS.ByteString -> ConversationActions Ping Pong Production -> Production ()
-                pong peerId _peerData cactions = do
+            let pong :: NodeId -> ConversationActions Ping Pong Production -> Production ()
+                pong peerId cactions = do
                     liftIO . putStrLn $ show anId ++ " sent PING to " ++ show peerId
                     received <- recv cactions
                     case received of
                         Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show peerId
                         Nothing -> error "Unexpected end of input"
-            forM_ peerIds $ \peerId -> withConnectionTo sendActions peerId (pong peerId)
+            forM_ peerIds $ \peerId -> withConnectionTo sendActions peerId $
+                \peerData -> Conversation (pong peerId)
             loop gen'
 
 listeners :: NodeId -> [Listener Packing BS.ByteString Production]

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -32,7 +32,8 @@ module Node (
     , Message (..)
     , messageName'
 
-    , SendActions(sendTo, withConnectionTo)
+    , Conversation(..)
+    , SendActions(withConnectionTo)
     , ConversationActions(send, recv)
     , Worker
     , Listener
@@ -92,12 +93,6 @@ type Worker packing peerData m = SendActions packing peerData m -> m ()
 type Listener = ListenerAction
 
 data ListenerAction packing peerData m where
-  -- | A listener that handles a single isolated incoming message
-  ListenerActionOneMsg
-    :: ( Serializable packing msg, Message msg )
-    => (peerData -> LL.NodeId -> SendActions packing peerData m -> msg -> m ())
-    -> ListenerAction packing peerData m
-
   -- | A listener that handles an incoming bi-directional conversation.
   ListenerActionConversation
     :: ( Packable packing snd, Unpackable packing rcv, Message rcv )
@@ -109,42 +104,30 @@ hoistListenerAction
     -> (forall a. m a -> n a)
     -> ListenerAction packing peerData n
     -> ListenerAction packing peerData m
-hoistListenerAction nat rnat (ListenerActionOneMsg f) = ListenerActionOneMsg $
-    \peerData nId sendActions -> nat . f peerData nId (hoistSendActions rnat nat sendActions)
 hoistListenerAction nat rnat (ListenerActionConversation f) = ListenerActionConversation $
     \peerData nId convActions -> nat $ f peerData nId (hoistConversationActions rnat convActions)
 
 -- | Gets message type basing on type of incoming messages
 listenerMessageName :: Listener packing peerData m -> MessageName
-listenerMessageName (ListenerActionOneMsg (
-        _ :: peerData -> LL.NodeId -> SendActions packing peerData m -> msg -> m ()
-    )) = messageName (Proxy :: Proxy msg)
-
 listenerMessageName (ListenerActionConversation (
         _ :: peerData -> LL.NodeId -> ConversationActions snd rcv m -> m ()
     )) = messageName (Proxy :: Proxy rcv)
 
-data SendActions packing peerData m = SendActions {
-       -- | Send a isolated (sessionless) message to a node
-       sendTo
-           :: forall msg .
-              ( Packable packing msg, Message msg )
-              => LL.NodeId
-              -> msg
-              -> m (),
+-- | Use ConversationActions on some Packable, Message send type, with an
+--   Unpackable receive type, in some functor m.
+data Conversation packingType m t where
+    Conversation
+        :: (Packable packingType snd, Unpackable packingType rcv, Message snd)
+        => (ConversationActions snd rcv m -> m t)
+        -> Conversation packingType m t
 
-       -- | Establish a bi-direction conversation session with a node.
-       withConnectionTo
-           :: forall snd rcv t .
-            ( Packable packing snd, Message snd, Unpackable packing rcv )
-           => LL.NodeId
-           -> (m peerData -> ConversationActions snd rcv m -> m t)
-           -> m t
+data SendActions packing peerData m = SendActions {
+       withConnectionTo :: forall t . LL.NodeId -> (peerData -> Conversation packing m t) -> m t
      }
 
 data ConversationActions body rcv m = ConversationActions {
        -- | Send a message within the context of this conversation
-       send     :: body -> m ()
+       send :: body -> m ()
 
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).
@@ -162,17 +145,17 @@ hoistConversationActions nat ConversationActions {..} =
         recv' = nat recv
 
 hoistSendActions
-    :: (forall a. n a -> m a)
+    :: forall packing peerData n m .
+       (forall a. n a -> m a)
     -> (forall a. m a -> n a)
     -> SendActions packing peerData n
     -> SendActions packing peerData m
-hoistSendActions nat rnat SendActions {..} = SendActions sendTo' withConnectionTo'
+hoistSendActions nat rnat SendActions {..} = SendActions withConnectionTo'
   where
-    sendTo' nodeId msg = nat $ sendTo nodeId msg
-    withConnectionTo' nodeId convActionsH =
-        nat $ withConnectionTo nodeId  $ \peerData convActions -> rnat $
-            convActionsH (nat peerData) $
-            hoistConversationActions nat convActions
+    withConnectionTo'
+        :: forall t . LL.NodeId -> (peerData -> Conversation packing m t) -> m t
+    withConnectionTo' nodeId k = nat $ withConnectionTo nodeId $ \peerData -> case k peerData of
+        Conversation l -> Conversation $ \cactions -> rnat (l (hoistConversationActions nat cactions))
 
 type ListenerIndex packing peerData m =
     Map MessageName (ListenerAction packing peerData m)
@@ -202,36 +185,22 @@ nodeSendActions
     -> packing
     -> SendActions packing peerData m
 nodeSendActions nodeUnit packing =
-    SendActions nodeSendTo nodeWithConnectionTo
+    SendActions nodeWithConnectionTo
   where
 
-    nodeSendTo
-        :: forall msg .
-           ( Packable packing msg, Message msg )
-        => LL.NodeId
-        -> msg
-        -> m ()
-    nodeSendTo = \nodeId msg ->
-        LL.withOutChannel nodeUnit nodeId $ \channelOut ->
-            LL.writeChannel channelOut $ concatMap LBS.toChunks
-                [ packMsg packing $ messageName' msg
-                , packMsg packing msg
-                ]
-
     nodeWithConnectionTo
-        :: forall snd rcv t .
-           ( Packable packing snd, Message snd, Unpackable packing rcv )
-        => LL.NodeId
-        -> (m peerData -> ConversationActions snd rcv m -> m t)
+        :: forall t .
+           LL.NodeId
+        -> (peerData -> Conversation packing m t)
         -> m t
-    nodeWithConnectionTo = \nodeId f ->
-        LL.withInOutChannel nodeUnit nodeId $ \peerDataVar inchan outchan -> do
-            let msgName  = messageName (Proxy :: Proxy snd)
-                cactions :: ConversationActions snd rcv m
-                cactions = nodeConversationActions nodeUnit nodeId packing inchan outchan
-            LL.writeChannel outchan . LBS.toChunks $
-                packMsg packing msgName
-            f (readSharedExclusive peerDataVar) cactions
+    nodeWithConnectionTo = \nodeId k ->
+        LL.withInOutChannel nodeUnit nodeId $ \peerData inchan outchan -> case k peerData of
+            Conversation (converse :: ConversationActions snd rcv m -> m t) -> do
+                let msgName = messageName (Proxy :: Proxy snd)
+                    cactions :: ConversationActions snd rcv m
+                    cactions = nodeConversationActions nodeUnit nodeId packing inchan outchan
+                LL.writeChannel outchan . LBS.toChunks $ packMsg packing msgName
+                converse cactions
 
 -- | Conversation actions for a given peer and in/out channels.
 nodeConversationActions
@@ -322,7 +291,6 @@ node mkEndPoint prng packing peerData nodeEnv k = do
               (mkEndPoint . LL.nodeState)
               prng
               nodeEnv
-              (handlerIn listenerIndex sendActions)
               (handlerInOut llnode listenerIndex)
         ; let sendActions = nodeSendActions llnode packing
         }
@@ -346,36 +314,6 @@ node mkEndPoint prng packing peerData nodeEnv k = do
     logNodeException e = do
         logError $ sformat ("exception while stopping node " % shown) e
         throw e
-    -- Handle incoming data from unidirectional connections: try to read the
-    -- message name, use it to determine a listener, parse the body, then
-    -- run the listener.
-    handlerIn
-        :: ListenerIndex packing peerData m
-        -> SendActions packing peerData m
-        -> peerData
-        -> LL.NodeId
-        -> ChannelIn m
-        -> m ()
-    handlerIn listenerIndex sendActions peerData peerId inchan = do
-        input <- recvNext inchan packing
-        case input of
-            End -> logDebug "handerIn : unexpected end of input"
-            -- TBD recurse and continue handling even after a no parse?
-            NoParse -> logDebug "handlerIn : failed to parse message name"
-            Input msgName -> do
-                let listener = M.lookup msgName listenerIndex
-                case listener of
-                    Just (ListenerActionOneMsg action) -> do
-                        input' <- recvNext inchan packing
-                        case input' of
-                            End -> logDebug "handerIn : unexpected end of input"
-                            NoParse -> logDebug "handlerIn : failed to parse message body"
-                            Input msgBody -> do
-                                action peerData peerId sendActions msgBody
-                    -- If it's a conversation listener, then that's an error, no?
-                    Just (ListenerActionConversation _) -> error ("handlerIn : wrong listener type. Expected unidirectional for " ++ show msgName)
-                    Nothing -> error ("handlerIn : no listener for " ++ show msgName)
-
     -- Handle incoming data from a bidirectional connection: try to read the
     -- message name, then choose a listener and fork a thread to run it.
     handlerInOut
@@ -397,7 +335,6 @@ node mkEndPoint prng packing peerData nodeEnv k = do
                     Just (ListenerActionConversation action) ->
                         let cactions = nodeConversationActions nodeUnit peerId packing inchan outchan
                         in  action peerData peerId cactions
-                    Just (ListenerActionOneMsg _) -> error ("handlerInOut : wrong listener type. Expected bidirectional for " ++ show msgName)
                     Nothing -> error ("handlerInOut : no listener for " ++ show msgName)
 
 recvNext

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -582,12 +582,10 @@ startNode
     -> StdGen
     -- ^ A source of randomness, for generating nonces.
     -> NodeEnvironment m
-    -> (peerData -> NodeId -> ChannelIn m -> m ())
-    -- ^ Handle incoming unidirectional connections.
     -> (peerData -> NodeId -> ChannelIn m -> ChannelOut m -> m ())
     -- ^ Handle incoming bidirectional connections.
     -> m (Node packingType peerData m)
-startNode packingType peerData mkNodeEndPoint prng nodeEnv handlerIn handlerOut = do
+startNode packingType peerData mkNodeEndPoint prng nodeEnv handlerOut = do
     rec { let nodeEndPoint = mkNodeEndPoint node
         ; mEndPoint <- newNodeEndPoint nodeEndPoint
         ; node <- case mEndPoint of
@@ -605,7 +603,7 @@ startNode packingType peerData mkNodeEndPoint prng nodeEnv handlerIn handlerOut 
                                 , nodePeerData         = peerData
                                 }
                       ; dispatcherThread <- async $
-                            nodeDispatcher node handlerIn handlerOut
+                            nodeDispatcher node handlerOut
                       -- Exceptions in the dispatcher are re-thrown here.
                       ; link dispatcherThread
                       }
@@ -740,10 +738,9 @@ nodeDispatcher
        , Message.Serializable packingType peerData
        , MonadFix m, WithLogger m, Show (ThreadId m) )
     => Node packingType peerData m
-    -> (peerData -> NodeId -> ChannelIn m -> m ())
     -> (peerData -> NodeId -> ChannelIn m -> ChannelOut m -> m ())
     -> m ()
-nodeDispatcher node handlerIn handlerInOut =
+nodeDispatcher node handlerInOut =
     loop initialDispatcherState
 
     where
@@ -981,19 +978,6 @@ nodeDispatcher node handlerIn handlerInOut =
                 Nothing -> return state
 
                 Just (w, ws)
-
-                    -- Got unidirectional header. Create a channel and
-                    -- spawn the application handler.
-                    | w == controlHeaderCodeUnidirectional -> do
-                          channel <- Channel.newChannel
-                          let provenance = Remote peer connid (ChannelIn channel)
-                          let handler = handlerIn peerData (NodeId peer) (ChannelIn channel)
-                          (_, incrBytes) <- spawnHandler nstate provenance handler
-                          Channel.writeChannel channel (Just ws)
-                          incrBytes $ BS.length ws
-                          return $ state {
-                                dsConnections = Map.insert connid (peer, FeedingApplicationHandler (ChannelIn channel) incrBytes) (dsConnections state)
-                              }
 
                     -- Got a bidirectional header but still waiting for the
                     -- nonce.
@@ -1352,7 +1336,7 @@ withInOutChannel
        , Message.Packable packingType peerData )
     => Node packingType peerData m
     -> NodeId
-    -> (SharedExclusiveT m peerData -> ChannelIn m -> ChannelOut m -> m a)
+    -> (peerData -> ChannelIn m -> ChannelOut m -> m a)
     -> m a
 withInOutChannel node@Node{nodeEnvironment, nodeState} nodeid@(NodeId peer) action = do
     nonce <- modifySharedAtomic nodeState $ \nodeState -> do
@@ -1381,7 +1365,9 @@ withInOutChannel node@Node{nodeEnvironment, nodeState} nodeid@(NodeId peer) acti
                       outcome <- NT.send conn [controlHeaderBidirectionalSyn nonce]
                       case outcome of
                           Left err -> throw err
-                          Right _ -> action peerDataVar channel (ChannelOut conn)
+                          Right _ -> do
+                              peerData <- readSharedExclusive peerDataVar
+                              action peerData channel (ChannelOut conn)
                   -- Here we spawn the timeout thread... Killing the 'promise'
                   -- is enough to clean everything up.
                   -- This timeout promise is included in the provenance, so

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -302,7 +302,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
     serverFinished <- newSharedExclusive
 
     let server = node (simpleNodeEndPoint transport) prng1 BinaryP () defaultNodeEnvironment $ \serverNode -> do
-            NodeAction listeners $ \_ -> do
+            NodeAction (const listeners) $ \_ -> do
                 -- Give our address to the client.
                 putSharedExclusive serverAddressVar (nodeId serverNode)
                 -- Don't stop until the client has finished.
@@ -313,7 +313,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
                 putSharedExclusive serverFinished ()
 
     let client = node (simpleNodeEndPoint transport) prng2 BinaryP () defaultNodeEnvironment $ \clientNode ->
-            NodeAction [] $ \sendActions -> do
+            NodeAction (const []) $ \sendActions -> do
                 serverAddress <- takeSharedExclusive serverAddressVar
                 void . forConcurrently workers $ \worker ->
                     worker serverAddress sendActions

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -78,7 +78,7 @@ import           Node                        (ConversationActions (..), Listener
                                               ListenerAction (..), Message (..),
                                               NodeAction (..), NodeId, SendActions (..),
                                               Worker, node, nodeId, defaultNodeEnvironment,
-                                              simpleNodeEndPoint)
+                                              simpleNodeEndPoint, Conversation (..))
 import           Node.Message                (BinaryP (..))
 
 -- | Run a computation, but kill it if it takes more than a given number of
@@ -209,13 +209,10 @@ awaitSTM time predicate = do
 
 -- | Way to send pack of messages
 data TalkStyle
-    = SingleMessageStyle
-    -- ^ corresponds to `sendTo` and `ListenerActionOneMsg` usage
-    | ConversationStyle
+    = ConversationStyle
     -- ^ corresponds to `withConnectionTo` and `ListenerActionConversation` usage
 
 instance Show TalkStyle where
-    show SingleMessageStyle = "single-message style"
     show ConversationStyle  = "conversation style"
 
 sendAll
@@ -232,17 +229,14 @@ sendAll
     -> NodeId
     -> [msg]
     -> m ()
-sendAll SingleMessageStyle sendActions peerId msgs =
-    --void $ forConcurrently msgs $ sendTo sendActions peerId
-    timeout "sendAll" 30000000 $ forM_ msgs $ sendTo sendActions peerId
-
 sendAll ConversationStyle sendActions peerId msgs =
     timeout "sendAll" 30000000 $
-        void . withConnectionTo sendActions @_ @Bool peerId $ \peerData cactions -> forM_ msgs $
-        \msg -> do
-            send cactions msg
-            _ <- recv cactions
-            pure ()
+        void . withConnectionTo sendActions peerId $ \peerData ->
+            Conversation $ \cactions -> forM_ msgs $
+                \msg -> do
+                    send cactions msg
+                    (_ :: Maybe Bool) <- recv cactions
+                    pure ()
 
 receiveAll
     :: ( Binary msg, Message msg, MonadIO m
@@ -255,8 +249,6 @@ receiveAll
     => TalkStyle
     -> (msg -> m ())
     -> ListenerAction BinaryP () m
-receiveAll SingleMessageStyle handler =
-    ListenerActionOneMsg $ \_ _ _ -> timeout "receiveAll" 30000000 . handler
 -- For conversation style, we send a response for every message received.
 -- The sender awaits a response for each message. This ensures that the
 -- sender doesn't finish before the conversation SYN/ACK completes.


### PR DESCRIPTION
Previously, sending a single message would not show the peer data. Now it does, because a single message interaction is just a conversation where one of the send or receive types is `Void`. The conversation does not proceed until the peer data of the remote peer is available, as it always will be because they must ACK the request, and peer data is always available if there's at least one incoming connection. (There is a longstanding but rare bug caused by `EventConnectionLost` which I'll fix soon).

Also included: the set of listeners is computed from the peer data each time a conversation is begun. In a typical application where the peer data specifies version information, this could be very useful: the set of listeners can depend upon the version info, rather than having a fixed set of listeners, each of which depends upon the version info (some of them probably wouldn't make any sense for certain versions).

This change may (probably will) negatively affect performance. Previously, some interactions could go ahead without waiting for the peer data. Now, necessarily, they will all wait for it. There's no avoiding that, but ideally the peer data would remain in memory across multiple interactions with a given peer. A simple way to improve things is to have a keepalive connection which stays up for, say, 30 seconds after the last application connection goes down. We could do that, but I think it's the wrong way around...

After many days of considering other options, I went with this solution because we need something now, and everything else is too radical and would require too much time. But I want to talk about the right way around so that we may eventually come to an agreement and schedule the work to be done.

The motivation for some keepalive connection comes from how time-warp is used in cardano-sl: threads contact peers basically whenever and wherever, with the understanding that some magic in time-warp will make everything maximally efficient. Since there's no application-level structure to the interaction with a given peer, all time-warp can do is guess that you may contact a peer again some time soon, hence the keepalive. I believe explicit sessions as described in #24 are a better solution. No keepalive necessary: the application explicitly delimits an interaction with a peer, in which the peer data is available and during which there need not be any conversations taking place. Instead of contacting peers whenever and wherever, an application is encouraged to establish sessions with those peers with which it anticipates recurring interaction. Those interactions are localized to the thread which establishes the session, and the nature of the interactions itself can depend upon the peer data, which is held across multiple conversations rather than delivered anew for each one.

An example to make things a little more concrete: instead of periodically broadcasting a piece of data to all neighbours by starting a bunch of independent conversations (which may require exchanging peer data), have a long-running *explicit* session with each of these neighbours, a thread for each, and push the data to broadcast to these threads.

tl;dr time-warp should not attempt to compensate for deficiencies in the architecture of the application (cardano-sl)