### PR TITLE
[TW-145] node can delay receives

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -23,7 +23,7 @@ import qualified Network.Transport.TCP      as TCP
 import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
                                              sendTo, defaultNodeEnvironment,
-                                             simpleNodeEndPoint)
+                                             simpleNodeEndPoint, noReceiveDelay)
 import           Node.Message               (BinaryP (..))
 import           ReceiverOptions            (Args (..), argsParser)
 
@@ -47,7 +47,7 @@ main = do
     let prng = mkStdGen 0
 
     runProduction $ usingLoggerName "receiver" $ do
-        node (simpleNodeEndPoint transport) prng BinaryP () defaultNodeEnvironment $ \_ ->
+        node (simpleNodeEndPoint transport) (const noReceiveDelay) prng BinaryP () defaultNodeEnvironment $ \_ ->
             NodeAction [pingListener noPong] $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -30,7 +30,7 @@ import           Network.Transport.Concrete     (concrete)
 import           Node                           (ListenerAction (..), Node (..),
                                                  NodeAction (..), defaultNodeEnvironment,
                                                  node, nodeEndPoint, sendTo,
-                                                 simpleNodeEndPoint)
+                                                 simpleNodeEndPoint, noReceiveDelay)
 import           Node.Internal                  (NodeId (..))
 import           Node.Message                   (BinaryP (..))
 
@@ -80,7 +80,7 @@ main = do
             let pingWorkers = liftA2 (pingSender prngWork payloadBound startTime msgRate)
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
-            node (simpleNodeEndPoint transport) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
+            node (simpleNodeEndPoint transport) (const noReceiveDelay) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
                 NodeAction [pongListener] $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -93,7 +93,7 @@ makeNode transport i = do
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    fork $ node (simpleNodeEndPoint transport) prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
+    fork $ node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
             discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node')

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -91,10 +91,10 @@ main = runProduction $ do
     let prng4 = mkStdGen 3
 
     liftIO . putStrLn $ "Starting nodes"
-    node (simpleNodeEndPoint transport) prng1 BinaryP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
+    node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
             _ <- setupMonitor 8000 runProduction node1
-            node (simpleNodeEndPoint transport) prng2 BinaryP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
+            node (simpleNodeEndPoint transport) (const noReceiveDelay) prng2 BinaryP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
                     _ <- setupMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -19,6 +19,9 @@ module Node (
       Node(..)
     , LL.NodeEnvironment(..)
     , LL.defaultNodeEnvironment
+    , LL.ReceiveDelay
+    , LL.noReceiveDelay
+    , LL.constantReceiveDelay
     , nodeEndPointAddress
     , NodeAction(..)
     , node
@@ -300,13 +303,14 @@ node
        , Serializable packing peerData
        )
     => (SharedAtomicT m (LL.NodeState peerData m) -> LL.NodeEndPoint m)
+    -> (SharedAtomicT m (LL.NodeState peerData m) -> LL.ReceiveDelay m)
     -> StdGen
     -> packing
     -> peerData
     -> LL.NodeEnvironment m
     -> (Node m -> NodeAction packing peerData m t)
     -> m t
-node mkEndPoint prng packing peerData nodeEnv k = do
+node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
     rec { let nId = LL.nodeId llnode
         ; let endPoint = LL.nodeEndPoint llnode
         ; let nodeUnit = Node nId endPoint (LL.nodeStatistics llnode)
@@ -320,6 +324,7 @@ node mkEndPoint prng packing peerData nodeEnv k = do
               packing
               peerData
               (mkEndPoint . LL.nodeState)
+              (mkReceiveDelay . LL.nodeState)
               prng
               nodeEnv
               (handlerIn listenerIndex sendActions)

--- a/test/Test/NodeSpec.hs
+++ b/test/Test/NodeSpec.hs
@@ -83,13 +83,13 @@ spec = describe "Node" $ do
                                 _ <- timeout "server sending response" 30000000 (send cactions (Parcel i (Payload 32)))
                                 return ()
 
-                let server = node (simpleNodeEndPoint transport) serverGen BinaryP ("server" :: String, 42 :: Int) defaultNodeEnvironment $ \_node ->
+                let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) serverGen BinaryP ("server" :: String, 42 :: Int) defaultNodeEnvironment $ \_node ->
                         NodeAction [listener] $ \sendActions -> do
                             putSharedExclusive serverAddressVar (nodeId _node)
                             takeSharedExclusive clientFinished
                             putSharedExclusive serverFinished ()
 
-                let client = node (simpleNodeEndPoint transport) clientGen BinaryP ("client" :: String, 24 :: Int) defaultNodeEnvironment $ \_node ->
+                let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) clientGen BinaryP ("client" :: String, 24 :: Int) defaultNodeEnvironment $ \_node ->
                         NodeAction [listener] $ \sendActions -> do
                             serverAddress <- readSharedExclusive serverAddressVar
                             forM_ [1..attempts] $ \i -> withConnectionTo sendActions serverAddress $ \peerData cactions -> do
@@ -129,7 +129,7 @@ spec = describe "Node" $ do
                                 _ <- send cactions (Parcel i (Payload 32))
                                 return ()
 
-                node (simpleNodeEndPoint transport) gen BinaryP ("some string" :: String, 42 :: Int) defaultNodeEnvironment $ \_node ->
+                node (simpleNodeEndPoint transport) (const noReceiveDelay) gen BinaryP ("some string" :: String, 42 :: Int) defaultNodeEnvironment $ \_node ->
                     NodeAction [listener] $ \sendActions -> do
                         forM_ [1..attempts] $ \i -> withConnectionTo sendActions (nodeId _node) $ \peerData cactions -> do
                             pd <- timeout "client waiting for peer data" 30000000 peerData
@@ -164,7 +164,7 @@ spec = describe "Node" $ do
                         handleThreadKilled Timeout = do
                             --liftIO . putStrLn $ "Thread killed successfully!"
                             return ()
-                    node (simpleNodeEndPoint transport) gen BinaryP () env $ \_node ->
+                    node (simpleNodeEndPoint transport) (const noReceiveDelay) gen BinaryP () env $ \_node ->
                         NodeAction [] $ \sendActions -> do
                             timeout "client waiting for ACK" 5000000 $
                                 flip catch handleThreadKilled $ withConnectionTo sendActions peerAddr $ \peerData cactions -> do

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -78,7 +78,7 @@ import           Node                        (ConversationActions (..), Listener
                                               ListenerAction (..), Message (..),
                                               NodeAction (..), NodeId, SendActions (..),
                                               Worker, node, nodeId, defaultNodeEnvironment,
-                                              simpleNodeEndPoint)
+                                              simpleNodeEndPoint, noReceiveDelay)
 import           Node.Message                (BinaryP (..))
 
 -- | Run a computation, but kill it if it takes more than a given number of
@@ -309,7 +309,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
     clientFinished <- newSharedExclusive
     serverFinished <- newSharedExclusive
 
-    let server = node (simpleNodeEndPoint transport) prng1 BinaryP () defaultNodeEnvironment $ \serverNode -> do
+    let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP () defaultNodeEnvironment $ \serverNode -> do
             NodeAction listeners $ \_ -> do
                 -- Give our address to the client.
                 putSharedExclusive serverAddressVar (nodeId serverNode)
@@ -320,7 +320,7 @@ deliveryTest transport_ testState workers listeners = runProduction $ do
                 -- Allow the client to stop.
                 putSharedExclusive serverFinished ()
 
-    let client = node (simpleNodeEndPoint transport) prng2 BinaryP () defaultNodeEnvironment $ \clientNode ->
+    let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) prng2 BinaryP () defaultNodeEnvironment $ \clientNode ->
             NodeAction [] $ \sendActions -> do
                 serverAddress <- takeSharedExclusive serverAddressVar
                 void . forConcurrently workers $ \worker ->


### PR DESCRIPTION
A 'ReceiveDelay' value can be given, defined possibly in terms of the
node state. It will be run before each network-transport 'receive' and
if a 'Just' is given, the dispatcher thread will delay for that many
microseconds before calling receive. The idea is that a sufficiently
smart choice for this can help a node deal with excess load.