### PR TITLE
Log our timewarp NodeId when we sart up a node

### DIFF
--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -611,6 +611,7 @@ startNode packingType peerData mkNodeEndPoint prng nodeEnv handlerIn handlerOut 
                       }
                   return node
         }
+    logDebug $ sformat ("startNode, we are " % shown % "") (nodeId node)
     return node
 
 -- | Stop a 'Node', closing its network transport and end point.


### PR DESCRIPTION
This will help in our logs to identify nodes.