### PR TITLE
[TW-148] import relay stuff from CSL

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -47,7 +47,7 @@ main = do
     let prng = mkStdGen 0
 
     runProduction $ usingLoggerName "receiver" $ do
-        node (simpleNodeEndPoint transport) (const noReceiveDelay) prng BinaryP () defaultNodeEnvironment $ \_ ->
+        node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) prng BinaryP () defaultNodeEnvironment $ \_ ->
             NodeAction (const [pingListener noPong]) $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -81,7 +81,7 @@ main = do
             let pingWorkers = liftA2 (pingSender prngWork payloadBound startTime msgRate)
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
-            node (simpleNodeEndPoint transport) (const noReceiveDelay) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
+            node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) prngNode BinaryP () defaultNodeEnvironment $ \node' ->
                 NodeAction (const []) $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -94,7 +94,8 @@ makeNode transport i = do
         prng1 = mkStdGen (2 * i)
         prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
-    fork $ node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
+    fork $ node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
+                prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
             discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node')

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -92,10 +92,12 @@ main = runProduction $ do
     let prng4 = mkStdGen 3
 
     liftIO . putStrLn $ "Starting nodes"
-    node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 StoreP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
+    node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
+         prng1 StoreP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
             _ <- startMonitor 8000 runProduction node1
-            node (simpleNodeEndPoint transport) (const noReceiveDelay) prng2 StoreP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
+            node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
+                  prng2 StoreP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
                     _ <- startMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -19,6 +19,11 @@ Library
                         Network.Transport.Concrete.TCP
                         Network.QDisc.Fair
 
+                        Network.Broadcast.Relay.Types
+                        Network.Broadcast.Relay.Class
+                        Network.Broadcast.Relay.Util
+                        Network.Broadcast.Relay.Logic
+
                         Node
 
                         Mockable
@@ -86,6 +91,7 @@ Library
                       , universum
                       , serokell-util
                       , stm
+                      , tagged == 0.8.5
                       , text
                       , text-format
                       , time

--- a/src/Network/Broadcast/Relay/Class.hs
+++ b/src/Network/Broadcast/Relay/Class.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE GADTs        #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Network.Broadcast.Relay.Class
+       ( Relay (..)
+       , InvReqDataParams (..)
+       , DataParams (..)
+       ) where
+
+import           Node                          (NodeId)
+import qualified Node.Message                  as Msg
+import           Universum
+
+import           Network.Broadcast.Relay.Types (ReqMsg, InvOrData, DataMsg,
+                                                PropagationMsg)
+
+-- | Data for general Inv/Req/Dat framework
+
+data Relay packingType m where
+  InvReqData ::
+      ( Buildable contents
+      , Buildable key
+      , Typeable contents
+      , Typeable key
+      , Eq key
+      , Msg.Serializable packingType (ReqMsg key)
+      , Msg.Serializable packingType (InvOrData key contents)
+      , Msg.Message (ReqMsg key)
+      , Msg.Message (InvOrData key contents)
+      )
+      => (PropagationMsg packingType -> m ()) -- ^ How to relay the data.
+      -> InvReqDataParams key contents m
+      -> Relay packingType m
+  Data ::
+      ( Buildable contents
+      , Typeable contents
+      , Msg.Serializable packingType (DataMsg contents)
+      , Msg.Message (DataMsg contents)
+      )
+      => (PropagationMsg packingType -> m ()) -- ^ How to relay the data.
+      -> DataParams contents m
+      -> Relay packingType m
+
+data InvReqDataParams key contents m =
+    InvReqDataParams
+        {
+        -- | Get key for given contents.
+          contentsToKey :: contents -> m key
+
+        -- | Handle inv msg and return whether it's useful or not
+        , handleInv     :: NodeId -> key -> m Bool
+
+        -- | Handle req msg and return (Just data) in case requested data can be provided
+        , handleReq     :: NodeId -> key -> m (Maybe contents)
+
+        -- | Handle data msg and return True if message is to be propagated
+        , handleData    :: NodeId -> contents -> m Bool
+        }
+
+data DataParams contents m = DataParams
+        { handleDataOnly :: NodeId -> contents -> m Bool
+        }

--- a/src/Network/Broadcast/Relay/Class.hs
+++ b/src/Network/Broadcast/Relay/Class.hs
@@ -9,7 +9,7 @@ module Network.Broadcast.Relay.Class
        ) where
 
 import           Node                          (NodeId)
-import qualified Node.Message                  as Msg
+import qualified Node.Message.Class            as Msg
 import           Universum
 
 import           Network.Broadcast.Relay.Types (ReqMsg, InvOrData, DataMsg,

--- a/src/Network/Broadcast/Relay/Logic.hs
+++ b/src/Network/Broadcast/Relay/Logic.hs
@@ -1,0 +1,322 @@
+-- | Framework for Inv\/Req\/Data message handling
+
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE FlexibleContexts    #-}
+
+module Network.Broadcast.Relay.Logic
+    ( relayListeners
+    , simpleRelayer
+
+      -- | Listeners for Inv, Req, and Data
+    , handleInvL
+    , handleReqL
+    , handleDataL
+    ) where
+
+import           Universum
+import           Formatting                         (build, sformat, (%))
+import           System.Wlog                        (WithLogger, logDebug, logWarning)
+
+import           Mockable                           (Mockable, Throw)
+import qualified Mockable.Concurrent                as Concurrent
+import qualified Mockable.Channel                   as Channel
+import           Node                               (Listener, ListenerAction (..),
+                                                     SendActions (..), Conversation (..),
+                                                     ConversationActions (..),
+                                                     NodeId)
+import qualified Node.Message                       as Msg
+import           Network.Broadcast.Relay.Types
+import           Network.Broadcast.Relay.Class
+import           Network.Broadcast.Relay.Util
+
+-- [Note: relaying induced by a listener]
+--
+-- This is the typical relay case: rather than than initiating the relay by
+-- sending 'InvMsg' to a bunch of peers, a node may be an intermediate step
+-- in the relaying, responding to an 'InvMsg' by sending a 'ReqMsg', receiving
+-- a 'DataMsg', and then sending an 'InvMsg' to a bunch of its peers.
+--
+-- This negotiation takes place inside a listener. Naturally we might want to
+-- do the relay from within that listener, but we can't because a listener does
+-- not have access to a node's 'SendActions'. This is for good reason: once
+-- the 'DataMsg' has come and its contents processed, the listener is finished.
+-- The initiating peer should not hold open its connection, nor should the
+-- contacted peer.
+--
+-- This is why a relay propagation queue was introduced in the original relay
+-- system, and that's why it remains in this one. A listener which wishes to
+-- relay will simply dump the `PropagationMsg` into the queue, and some other
+-- system takes care of clearing that queue, possibly according to some
+-- sohpisticated QoS policy.
+
+-- | Create listeners for one particular relay description. Include these
+--   as listeners in your node and it will carry out a relay broadcast for
+--   this particular relay description.
+listenersForRelay
+    :: forall packingType peerData m .
+       ( Msg.Message Void
+       , Msg.Packable packingType Void
+       , WithLogger m
+       , Mockable Throw m
+       )
+    => Relay packingType m
+    -> [Listener packingType peerData m]
+listenersForRelay (InvReqData mP irdP@InvReqDataParams{..}) =
+    [handleReqL handleReq, handleInvL mP irdP]
+listenersForRelay (Data mP DataParams{..}) =
+    [handleDataL mP handleDataOnly]
+
+-- | Create listeners for a list of relay descriptions. Include these as
+--   listeners in your node and it will carry out a relay broadcast.
+relayListeners
+    :: forall packingType peerData m .
+       ( Msg.Message Void
+       , Msg.Packable packingType Void
+       , WithLogger m
+       , Mockable Throw m
+       )
+    => [Relay packingType m]
+    -> [Listener packingType peerData m]
+relayListeners = (>>= listenersForRelay)
+
+-- | Create a relayed which uses a single bounded queue for every message to
+--   be relayed. The first component is the relayed to be included in the
+--   Relay descriptor definitions (for particular data types) and the second
+--   component will, given network capabilities, forever pull from the queue and
+--   relay the messages (you should probably spawn a thread for it).
+--
+--   TODO use a bounded queue!
+--
+--   TODO currently we take an 'Maybe NodeId -> m (Set NodeId)' to discover who
+--   we ought to relay to. The parameter is the node who relayed it to us, or
+--   Nothing if we're initiating. We may want to replace this with the
+--   Discovery abstraction.
+simpleRelayer
+    :: forall packingType peerData m .
+       ( Msg.Serializable packingType Void
+       , Mockable Channel.Channel m
+       , Mockable Concurrent.Concurrently m
+       , WithLogger m
+       )
+    => (Maybe NodeId -> m (Set NodeId))
+    -> m (PropagationMsg packingType -> m (), SendActions packingType peerData m -> m ())
+simpleRelayer getTargets = do
+    queue <- Channel.newChannel
+
+    let fillQueue :: PropagationMsg packingType -> m ()
+        fillQueue = Channel.writeChannel queue
+
+    let clearQueue :: SendActions packingType peerData m -> m ()
+        clearQueue sactions = do
+            msg <- Channel.readChannel queue
+            propagateOne sactions msg
+            clearQueue sactions
+
+    return (fillQueue, clearQueue)
+
+  where
+
+    -- Propagate one message to a set of peers.
+    -- It does so concurrently, one thread for each peer, and will not finish
+    -- until all have finished.
+    propagateOne :: SendActions packingType peerData m -> PropagationMsg packingType -> m ()
+    propagateOne sactions (InvReqDataPM mPeer key value) = do
+        logDebug $ sformat ("Propagation data with key: "%build) key
+        targets <- getTargets mPeer
+        void $ Concurrent.forConcurrently (toList targets) $ \peer ->
+            withConnectionTo sactions peer $ \_ -> Conversation (invReqDataConversation key value)
+    propagateOne sactions (DataOnlyPM mPeer value) = do
+        logDebug $ sformat ("Propagation data: "%build) value
+        targets <- getTargets mPeer
+        void $ Concurrent.forConcurrently (toList targets) $ \peer ->
+            withConnectionTo sactions peer $ \_ -> Conversation (dataConversation value)
+
+
+    dataConversation
+        :: forall value .
+           value
+        -> ConversationActions (DataMsg value) Void m
+        -> m ()
+    dataConversation value conv = send conv $ DataMsg value
+
+    invReqDataConversation
+        :: forall key value .
+           ( Eq key )
+        => key
+        -> value
+        -> ConversationActions (InvOrData key value) (ReqMsg key) m
+        -> m ()
+    invReqDataConversation key conts conv = do
+        send conv $ Left $ InvMsg key
+        let whileNotK = do
+              rm <- recv conv
+              whenJust rm $ \ReqMsg{..} -> do
+                if rmKey == key
+                   then send conv $ Right $ DataMsg conts
+                   else whileNotK
+        whileNotK
+
+-- | A listener for 'ReqMsg', given a way to produce a value from a key
+--   within some monad. It will send back a `DataMsg` with the value if it is
+--   found.
+--
+--   TBD why do we need this 'ReqMsg' listener? This seems to have nothing
+--   to do with relaying. It's an unsolicited query for some key/value pair,
+--   which induces no further relaying. Seems unrelated to relay/broadcast.
+handleReqL
+    :: forall packingType peerData key value m .
+       ( Msg.Serializable packingType (ReqMsg key)
+       , Msg.Serializable packingType (InvOrData key value)
+       , Msg.Message (InvOrData key value)
+       , Msg.Message (ReqMsg key)
+       , Buildable key
+       , WithLogger m
+       )
+    => (NodeId -> key -> m (Maybe value))
+    -> Listener packingType peerData m
+handleReqL handleReq = ListenerActionConversation $ \_ peer cactions ->
+   let handlingLoop = do
+           mbMsg <- recv cactions
+           whenJust mbMsg $ \ReqMsg{..} -> do
+               dtMB <- handleReq peer rmKey
+               case dtMB of
+                   Nothing -> logNoData rmKey
+                   Just dt -> logHaveData rmKey >> send cactions (constructDataMsg dt)
+               handlingLoop
+    in handlingLoop
+  where
+    constructDataMsg :: value -> InvOrData key value
+    constructDataMsg = Right . DataMsg
+    logNoData rmKey = logDebug $ sformat
+        ("We don't have data for key "%build)
+        rmKey
+    logHaveData rmKey= logDebug $ sformat
+        ("We have data for key "%build)
+        rmKey
+
+-- | A listener for 'InvMsg'. In fact, it expects 'InvOrData' because it may
+--   send a 'ReqMsg' after the initial 'InvMsg', after which it will expect
+--   a 'DataMsg'.
+handleInvL
+  :: forall packingType peerData key value m .
+     ( Msg.Message (ReqMsg key)
+     , Msg.Message (InvOrData key value)
+     , Msg.Serializable packingType (ReqMsg key)
+     , Msg.Serializable packingType (InvOrData key value)
+     , Buildable key
+     , Buildable value
+     , Eq key
+     , WithLogger m
+     , Mockable Throw m
+     )
+  => (PropagationMsg packingType -> m ()) -- ^ How to relay the data.
+  -> InvReqDataParams key value m
+  -> Listener packingType peerData m
+handleInvL propagateData InvReqDataParams{..} = ListenerActionConversation $ \_ peer cactions ->
+    let handlingLoop = do
+            -- Expect an 'InvMsg'.
+            -- Actually, this is 'InvOrData', and we give an error in case
+            -- 'DataMsg' is observed first (expectInv).
+            inv' <- recv cactions
+            whenJust inv' $ expectInv $ \InvMsg{..} -> do
+                -- 'handleInv' comes from the 'InvReqDataParams' record.
+                -- Note that 'handleInvDo' returns a new key 'useful'
+                -- TBD will it always be the same as 'imKey'? You'd think so...
+                useful <- handleInvDo (handleInv peer) imKey
+                whenJust useful $ \ne -> do
+                    -- We think their 'InvMsg' key is useful so we request
+                    -- the data.
+                    send cactions $ ReqMsg ne
+                    -- Now the pattern repeats but we expect a 'DataMsg'.
+                    dt' <- recv cactions
+                    whenJust dt' $ expectData $ \DataMsg{..} -> do
+                          handleDataDo peer propagateData contentsToKey (handleData peer) dmContents
+                          -- handlingLoop
+
+                          -- TODO CSL-1148 Improve relaing: support multiple data
+                          -- Need to receive Inv and Data messages simultaneously
+                          -- Maintain state of sent Reqs
+                          -- And check data we are sent is what we expect (currently not)
+    in handlingLoop
+
+
+
+-- | Make a listener for 'DataMsg', given a way to decide whether the propagate
+--   the data, and possibly do something with it in the monadic context.
+handleDataL
+    :: forall packingType peerData value m .
+       ( Msg.Serializable packingType (DataMsg value)
+       , Msg.Packable packingType Void
+       , Msg.Message Void
+       , Msg.Message (DataMsg value)
+       , Buildable value
+       , WithLogger m
+       )
+    => (PropagationMsg packingType -> m ()) -- ^ How to relay the data.
+    -> (NodeId -> value -> m Bool) -- ^ Give 'True' to propagate, 'False' otherwise.
+    -> Listener packingType peerData m
+handleDataL propagateData handleData = ListenerActionConversation $ \_ peer (cactions :: ConversationActions Void (DataMsg value) m) ->
+    let handlingLoop = do
+            mbMsg <- recv cactions
+            whenJust mbMsg $ \DataMsg{..} -> do
+                ifM (handleData peer dmContents)
+                    (propagateData $ constructDataOnlyPM peer dmContents)
+                    (logUseless dmContents)
+                handlingLoop
+    in handlingLoop
+  where
+    constructDataOnlyPM :: NodeId -> value -> PropagationMsg packingType
+    constructDataOnlyPM = DataOnlyPM . Just
+    logUseless dmContents = logWarning $ sformat
+        ("Ignoring data "%build) dmContents
+
+-- | Given a value, determine its key and whether it should propagate.
+handleDataDo
+    :: forall packingType key value m .
+       ( Buildable key
+       , Eq key
+       , Buildable value
+       , Msg.Message (InvOrData key value)
+       , Msg.Message (ReqMsg key)
+       , Msg.Serializable packingType (InvOrData key value)
+       , Msg.Serializable packingType (ReqMsg key)
+       , WithLogger m
+       )
+    => NodeId -- ^ The peer which gave the data.
+    -> (PropagationMsg packingType -> m ())
+    -> (value -> m key)  -- ^ value determines its own key (with effects)
+    -> (value -> m Bool) -- ^ value determines whether it should propagate (with effects)
+    -> value
+    -> m ()
+handleDataDo peer propagateData contentsToKey handleData dmContents = do
+    -- TBD is it important to run this effects before running 'handleData'?
+    -- Seems ideal to run this only if we actually need the key (for something
+    -- other than logging).
+    dmKey <- contentsToKey dmContents
+    ifM (handleData dmContents)
+        (propagateData $ InvReqDataPM (Just peer) dmKey dmContents) $
+            logDebug $ sformat
+                ("Ignoring data "%build%" for key "%build) dmContents dmKey
+
+-- | Determine whether a key is useful and do some logging.
+handleInvDo
+    :: forall key m .
+       ( Buildable key
+       , WithLogger m
+       )
+    => (key -> m Bool)
+    -> key
+    -> m (Maybe key)
+handleInvDo decide imKey =
+    ifM (decide imKey)
+        (Just imKey <$ logUseful)
+        (Nothing <$ logUseless)
+  where
+    logUseless = logDebug $ sformat
+        ("Ignoring inv for key "%build%", because it's useless")
+        imKey
+    logUseful = logDebug $ sformat
+        ("We'll request data for key "%build%", because it's useful")
+        imKey

--- a/src/Network/Broadcast/Relay/Types.hs
+++ b/src/Network/Broadcast/Relay/Types.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Network.Broadcast.Relay.Types
+       ( RelayError (..)
+       , PropagationMsg (..)
+       , InvMsg (..)
+       , ReqMsg (..)
+       , DataMsg (..)
+       , InvOrData
+       , InvOrDataTK
+       , propagationMsgProvenance
+       ) where
+
+import           Control.Lens                  (Wrapped (..), iso)
+import qualified Data.Text.Buildable           as Buildable
+import           Data.Tagged                   (Tagged)
+import           Formatting                    (bprint, shown, build, (%))
+import           Universum
+
+import           Node                          (NodeId)
+import qualified Node.Message                  as Msg
+
+data RelayError = UnexpectedInv
+                | UnexpectedData
+  deriving (Generic, Show)
+
+instance Exception RelayError
+
+-- | A message to be propagated (relayed) to peers.
+data PropagationMsg packingType where
+    InvReqDataPM ::
+        ( Msg.Message (InvOrData key contents)
+        , Msg.Serializable packingType (InvOrData key contents)
+        , Buildable key
+        , Eq key
+        , Msg.Message (ReqMsg key)
+        , Msg.Serializable packingType (ReqMsg key))
+        => !(Maybe NodeId) -- ^ The peer which sent it to us.
+        -> !key            -- ^ The key (will 'InvMsg' this to peers).
+        -> !contents       -- ^ The data associated with the key.
+        -> PropagationMsg packingType
+    DataOnlyPM ::
+        ( Msg.Message (DataMsg contents)
+        , Msg.Serializable packingType (DataMsg contents)
+        , Buildable contents)
+        => !(Maybe NodeId) -- ^ The peer which sent it to us.
+        -> !contents       -- ^ The data.
+        -> PropagationMsg packingType
+
+instance Buildable (PropagationMsg packingType) where
+    build (InvReqDataPM peer key _) =
+        bprint ("<data from peer "%shown%" for key "%build%">") peer key
+    build (DataOnlyPM peer conts) =
+        bprint ("<data from peer "%shown%" "%build) peer (Buildable.build conts)
+
+-- | The peer from which the data to be propagated has come (or Nothing if
+--   it originated locally).
+propagationMsgProvenance
+    :: PropagationMsg packingType
+    -> Maybe NodeId
+propagationMsgProvenance (InvReqDataPM mPeer _ _) = mPeer
+propagationMsgProvenance (DataOnlyPM mPeer _)     = mPeer
+
+-- | Inventory message. Can be used to announce the fact that you have
+-- some data.
+data InvMsg key = InvMsg
+    { imKey :: !key
+    }
+    deriving (Show, Eq)
+
+-- | Request message. Can be used to request data (ideally data which
+-- was previously announced by inventory message).
+data ReqMsg key = ReqMsg
+    { rmKey :: !key
+    }
+    deriving (Show, Eq)
+
+-- | Data message. Can be used to send actual data.
+data DataMsg contents = DataMsg
+    { dmContents :: !contents
+    } deriving (Show, Eq)
+
+type InvOrData key contents = Either (InvMsg key) (DataMsg contents)
+
+-- | InvOrData with key tagged by contents
+type InvOrDataTK key contents = InvOrData (Tagged contents key) contents
+
+instance (Buildable contents) =>
+         Buildable (DataMsg contents) where
+    build (DataMsg contents) = bprint ("Data {" %build % "}") contents
+
+instance Wrapped (DataMsg contents) where
+    type Unwrapped (DataMsg contents) = contents
+    _Wrapped' = iso dmContents DataMsg

--- a/src/Network/Broadcast/Relay/Types.hs
+++ b/src/Network/Broadcast/Relay/Types.hs
@@ -20,7 +20,7 @@ import           Formatting                    (bprint, shown, build, (%))
 import           Universum
 
 import           Node                          (NodeId)
-import qualified Node.Message                  as Msg
+import qualified Node.Message.Class            as Msg
 
 data RelayError = UnexpectedInv
                 | UnexpectedData

--- a/src/Network/Broadcast/Relay/Util.hs
+++ b/src/Network/Broadcast/Relay/Util.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Network.Broadcast.Relay.Util
+       ( expectInv
+       , expectData
+       ) where
+
+import           Mockable                      (Mockable, Throw, throw)
+
+import           Network.Broadcast.Relay.Types (DataMsg, InvMsg, InvOrData,
+                                                RelayError(..))
+
+expectInv
+    :: Mockable Throw m
+    => (InvMsg key -> m a) -> InvOrData key contents -> m a
+expectInv call = either call (\_ -> throw UnexpectedData)
+
+expectData
+    :: Mockable Throw m
+    => (DataMsg contents -> m a) -> InvOrData key contents -> m a
+expectData call = either (\_ -> throw UnexpectedInv) call

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -293,13 +293,14 @@ node
        )
     => (m (LL.Statistics m) -> LL.NodeEndPoint m)
     -> (m (LL.Statistics m) -> LL.ReceiveDelay m)
+    -> (m (LL.Statistics m) -> LL.ReceiveDelay m)
     -> StdGen
     -> packing
     -> peerData
     -> LL.NodeEnvironment m
     -> (Node m -> NodeAction packing peerData m t)
     -> m t
-node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
+node mkEndPoint mkReceiveDelay mkConnectDelay prng packing peerData nodeEnv k = do
     rec { let nId = LL.nodeId llnode
         ; let endPoint = LL.nodeEndPoint llnode
         ; let nodeUnit = Node nId endPoint (LL.nodeStatistics llnode)
@@ -314,6 +315,7 @@ node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
               peerData
               (mkEndPoint . LL.nodeStatistics)
               (mkReceiveDelay . LL.nodeStatistics)
+              (mkConnectDelay . LL.nodeStatistics)
               prng
               nodeEnv
               (handlerInOut llnode listenerIndices)

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -309,7 +309,7 @@ deliveryTest transport_ nodeEnv testState workers listeners = runProduction $ do
     clientFinished <- newSharedExclusive
     serverFinished <- newSharedExclusive
 
-    let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP () nodeEnv $ \serverNode -> do
+    let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) prng1 BinaryP () nodeEnv $ \serverNode -> do
             NodeAction (const listeners) $ \_ -> do
                 -- Give our address to the client.
                 putSharedExclusive serverAddressVar (nodeId serverNode)
@@ -320,7 +320,7 @@ deliveryTest transport_ nodeEnv testState workers listeners = runProduction $ do
                 -- Allow the client to stop.
                 putSharedExclusive serverFinished ()
 
-    let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) prng2 BinaryP () nodeEnv $ \clientNode ->
+    let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) prng2 BinaryP () nodeEnv $ \clientNode ->
             NodeAction (const []) $ \sendActions -> do
                 serverAddress <- takeSharedExclusive serverAddressVar
                 let act = void . forConcurrently workers $ \worker ->


### PR DESCRIPTION
Inv/Req/Data relaying mechanism spliced from cardano-sl and stripped down to what (I'm fairly sure) is minimally sufficient for relay broadcast.

```Haskell
-- 'relayer' relays a message, in this particular case by putting it into a queue
-- which is cleared by 'relayWorker', in the same way that the current cardano-sl
-- implementation does it (concurrent send to all neighbours).
-- However this one is parameterized by the way in which the targets are
-- determined.
(relayer, relayWorker) <- simpleRelayer (determineNextTarget :: Maybe NodeId -> m (Set NodeId))
-- Relay listeners need to know how to relay (a field in the 'Relay' datatype).
let listeners = relayListeners
        [ relayGroup1 relayer :: Relay packingType m
        , relayGroup2 relayer :: Relay packingType m
        ]
-- An example 'NodeAction': it has the relay listeners and immediately spawns a
-- thread to execute the relays in the usual naive single-queue way.
let nodeAction :: NodeAction packingType peerData m
    nodeAction = NodeAction (const listeners) $ \sactions ->
        wtihAsync (relayWorker sactions) $ \relayThread -> do
            -- You can initiate a relay like this.
            -- The 'Nothing' has type 'Maybe NodeId', giving the provenance of the
            -- relay message ('Just peer' means we're relaying for that peer).
            relayer (InvReqDataPM Nothing someKey someValue)
            ...
        
...
```