### PR TITLE
[TW-149] Redesign of message serialization

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -24,7 +24,7 @@ import           Network.Transport.Concrete (concrete)
 import           Node                       (ListenerAction (..), NodeAction (..), node,
                                              defaultNodeEnvironment, ConversationActions (..),
                                              simpleNodeEndPoint, noReceiveDelay)
-import           Node.Message               (BinaryP (..))
+import           Node.Message.Binary        (BinaryP (..))
 import           ReceiverOptions            (Args (..), argsParser)
 
 main :: IO ()
@@ -53,7 +53,7 @@ main = do
   where
     pingListener noPong =
         ListenerActionConversation $ \_ _ cactions -> do
-            Just (Ping mid payload) <- recv cactions
+            Just (Ping mid payload) <- recv cactions maxBound
             logMeasure PingReceived mid payload
             unless noPong $ do
                 logMeasure PongSent mid payload

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -28,12 +28,12 @@ import           Mockable                       (Production, delay, fork, realTi
 import qualified Network.Transport.Abstract     as NT
 import           Network.Transport.Concrete     (concrete)
 import           Node                           (NodeAction (..), node, Node(Node),
-                                                 nodeEndPoint, SendActions (..),
+                                                 SendActions (..),
                                                  Conversation (..), ConversationActions (..),
                                                  defaultNodeEnvironment, simpleNodeEndPoint,
                                                  noReceiveDelay)
 import           Node.Internal                  (NodeId (..))
-import           Node.Message                   (BinaryP (..))
+import           Node.Message.Binary            (BinaryP (..))
 
 
 import           Bench.Network.Commons          (MeasureEvent (..), Payload (..),
@@ -101,7 +101,7 @@ main = do
             lift . lift $ withConnectionTo sendActions peerId $
                 \_ -> Conversation $ \cactions -> do
                     send cactions (Ping sMsgId payload)
-                    Just (Pong _ _) <- recv cactions
+                    Just (Pong _ _) <- recv cactions maxBound
                     return ()
 
             PingState{..}    <- get

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -28,7 +28,7 @@ import           Network.Transport.Abstract           (Transport (..))
 import           Network.Transport.Concrete           (concrete)
 import qualified Network.Transport.TCP                as TCP
 import           Node
-import           Node.Message                         (BinaryP (..))
+import           Node.Message.Binary                  (BinaryP (..))
 import           System.Environment                   (getArgs)
 import           System.Random
 
@@ -62,7 +62,7 @@ worker anId generator discovery = pingWorker generator
             liftIO . putStrLn $ show anId ++ " has peer set: " ++ show peerSet
             forM_ (S.toList peerSet) $ \addr -> withConnectionTo sendActions (NodeId addr) $
                 \_peerData -> Conversation $ \(cactions :: ConversationActions Void Pong Production) -> do
-                    received <- recv cactions
+                    received <- recv cactions maxBound
                     case received of
                         Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show addr
                         Nothing -> error "Unexpected end of input"

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -14,7 +14,7 @@ module Main where
 
 import           Control.Monad              (forM_)
 import           Control.Monad.IO.Class     (liftIO)
-import           Data.Binary
+import           Data.Store                 (Store)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Char8      as B8
 import           Data.Data                  (Data)
@@ -26,7 +26,7 @@ import           Network.Transport.Abstract (closeTransport)
 import           Network.Transport.Concrete (concrete)
 import qualified Network.Transport.TCP      as TCP
 import           Node
-import           Node.Message               (BinaryP (..))
+import           Node.Message.Store         (StoreP (..))
 import           Node.Util.Monitor          (startMonitor)
 import           System.Random
 
@@ -35,7 +35,7 @@ data Ping = Ping
 deriving instance Generic Ping
 deriving instance Data Ping
 deriving instance Show Ping
-instance Binary Ping
+instance Store Ping
 instance Message Ping where
     formatMessage _ = "Ping"
 
@@ -43,9 +43,9 @@ instance Message Ping where
 data Pong = Pong
 deriving instance Generic Pong
 deriving instance Show Pong
-instance Binary Pong
+instance Store Pong
 
-type Packing = BinaryP
+type Packing = StoreP
 
 worker :: NodeId -> StdGen -> [NodeId] -> Worker Packing BS.ByteString Production
 worker anId generator peerIds = pingWorker generator
@@ -61,7 +61,7 @@ worker anId generator peerIds = pingWorker generator
             let pong :: NodeId -> ConversationActions Ping Pong Production -> Production ()
                 pong peerId cactions = do
                     liftIO . putStrLn $ show anId ++ " sent PING to " ++ show peerId
-                    received <- recv cactions
+                    received <- recv cactions maxBound
                     case received of
                         Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show peerId
                         Nothing -> error "Unexpected end of input"
@@ -92,10 +92,10 @@ main = runProduction $ do
     let prng4 = mkStdGen 3
 
     liftIO . putStrLn $ "Starting nodes"
-    node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
+    node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 StoreP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
             _ <- startMonitor 8000 runProduction node1
-            node (simpleNodeEndPoint transport) (const noReceiveDelay) prng2 BinaryP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
+            node (simpleNodeEndPoint transport) (const noReceiveDelay) prng2 StoreP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
                     _ <- startMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -35,7 +35,10 @@ Library
                         Mockable.Metrics
 
                         Node.Internal
-                        Node.Message
+                        Node.Message.Decoder
+                        Node.Message.Class
+                        Node.Message.Binary
+                        Node.Message.Store
 
                         Node.Util.Monitor
 
@@ -86,6 +89,7 @@ Library
                       , ekg
                       , mwc-random
                       , statistics
+                      , store
                       , vector
 
   hs-source-dirs:       src
@@ -126,6 +130,7 @@ executable ping-pong
                      , node-sketch
                      , random
                      , stm
+                     , store
                      , time-units
 
   hs-source-dirs:      examples

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -351,7 +351,7 @@ node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
         -> m ()
     handlerInOut nodeUnit listenerIndices peerData peerId inchan outchan = do
         let listenerIndex = listenerIndices peerData
-        input <- recvNext packing messageSizeLimit inchan
+        input <- recvNext packing messageNameSizeLimit inchan
         case input of
             End -> logDebug "handlerInOut : unexpected end of input"
             Input msgName -> do
@@ -363,8 +363,8 @@ node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
                     Nothing -> error ("handlerInOut : no listener for " ++ show msgName)
     -- Arbitrary limit on the message size...
     -- TODO make it configurable I guess.
-    messageSizeLimit :: Int
-    messageSizeLimit = 256
+    messageNameSizeLimit :: Int
+    messageNameSizeLimit = 256
 
 -- | Try to receive and parse the next message, subject to a limit on the
 --   number of bytes which will be read.

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -91,13 +91,6 @@ data Node m = Node {
 nodeEndPointAddress :: Node m -> NT.EndPointAddress
 nodeEndPointAddress (Node addr _ _) = LL.nodeEndPointAddress addr
 
--- | Maximum transmission unit: you can't send more than this many bytes in
---   one call. It's assumed to be lower than the network-transport 
---
---   TODO make it configurable.
-mtu :: Word32
-mtu = 4096
-
 data Input t = Input t | End
 
 data LimitExceeded = LimitExceeded
@@ -214,6 +207,8 @@ nodeSendActions nodeUnit packing =
     SendActions nodeWithConnectionTo
   where
 
+    mtu = LL.nodeMtu (LL.nodeEnvironment nodeUnit)
+
     nodeWithConnectionTo
         :: forall t .
            LL.NodeId
@@ -242,9 +237,11 @@ nodeConversationActions
     -> ChannelIn m
     -> ChannelOut m
     -> ConversationActions snd rcv m
-nodeConversationActions _ _ packing inchan outchan =
+nodeConversationActions node _ packing inchan outchan =
     ConversationActions nodeSend nodeRecv
     where
+
+    mtu = LL.nodeMtu (LL.nodeEnvironment node)
 
     nodeSend = \body -> do
         LL.writeMany mtu outchan (packMsg packing body)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE BangPatterns               #-}
 
 module Node (
 
@@ -54,15 +55,15 @@ module Node (
 
     ) where
 
-import           Control.Exception          (SomeException)
-import           Control.Monad              (unless)
+import           Control.Exception          (SomeException, Exception)
+import           Control.Monad              (unless, when)
 import           Control.Monad.Fix          (MonadFix)
-import qualified Data.Binary.Get            as Bin
 import qualified Data.ByteString            as BS
-import qualified Data.ByteString.Lazy       as LBS
 import           Data.Map.Strict            (Map)
 import qualified Data.Map.Strict            as M
 import           Data.Proxy                 (Proxy (..))
+import           Data.Typeable              (Typeable)
+import           Data.Word                  (Word32)
 import           Formatting                 (sformat, shown, (%))
 import qualified Mockable.Channel           as Channel
 import           Mockable.Class
@@ -75,7 +76,9 @@ import           Mockable.SharedExclusive
 import qualified Network.Transport.Abstract as NT
 import           Node.Internal              (ChannelIn, ChannelOut)
 import qualified Node.Internal              as LL
-import           Node.Message
+import           Node.Message.Class         (Serializable (..), MessageName,
+                                             Message (..), messageName')
+import           Node.Message.Decoder       (Decoder (..), continueDecoding)
 import           System.Random              (StdGen)
 import           System.Wlog                (WithLogger, logDebug, logError, logInfo)
 
@@ -88,7 +91,24 @@ data Node m = Node {
 nodeEndPointAddress :: Node m -> NT.EndPointAddress
 nodeEndPointAddress (Node addr _ _) = LL.nodeEndPointAddress addr
 
-data Input t = Input t | NoParse | End
+-- | Maximum transmission unit: you can't send more than this many bytes in
+--   one call. It's assumed to be lower than the network-transport 
+--
+--   TODO make it configurable.
+mtu :: Word32
+mtu = 4096
+
+data Input t = Input t | End
+
+data LimitExceeded = LimitExceeded
+  deriving (Show, Typeable)
+
+instance Exception LimitExceeded
+
+data NoParse = NoParse
+  deriving (Show, Typeable)
+
+instance Exception NoParse
 
 type Worker packing peerData m = SendActions packing peerData m -> m ()
 
@@ -98,7 +118,7 @@ type Listener = ListenerAction
 data ListenerAction packing peerData m where
   -- | A listener that handles an incoming bi-directional conversation.
   ListenerActionConversation
-    :: ( Packable packing snd, Unpackable packing rcv, Message rcv )
+    :: ( Serializable packing snd, Serializable packing rcv, Message rcv )
     => (peerData -> LL.NodeId -> ConversationActions snd rcv m -> m ())
     -> ListenerAction packing peerData m
 
@@ -116,11 +136,11 @@ listenerMessageName (ListenerActionConversation (
         _ :: peerData -> LL.NodeId -> ConversationActions snd rcv m -> m ()
     )) = messageName (Proxy :: Proxy rcv)
 
--- | Use ConversationActions on some Packable, Message send type, with an
---   Unpackable receive type, in some functor m.
+-- | Use ConversationActions on some Serializable, Message send type, with a
+--   Serializable receive type.
 data Conversation packingType m t where
     Conversation
-        :: (Packable packingType snd, Unpackable packingType rcv, Message snd)
+        :: (Serializable packingType snd, Serializable packingType rcv, Message snd)
         => (ConversationActions snd rcv m -> m t)
         -> Conversation packingType m t
 
@@ -134,7 +154,7 @@ data ConversationActions body rcv m = ConversationActions {
 
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).
-     , recv :: m (Maybe rcv)
+     , recv :: Word32 -> m (Maybe rcv)
      }
 
 hoistConversationActions
@@ -145,7 +165,7 @@ hoistConversationActions nat ConversationActions {..} =
   ConversationActions send' recv'
       where
         send' = nat . send
-        recv' = nat recv
+        recv' = nat . recv
 
 hoistSendActions
     :: forall packing peerData n m .
@@ -183,7 +203,7 @@ nodeSendActions
        , Mockable Delay m
        , WithLogger m, MonadFix m
        , Serializable packing peerData
-       , Packable packing MessageName )
+       , Serializable packing MessageName )
     => LL.Node packing peerData m
     -> packing
     -> SendActions packing peerData m
@@ -202,7 +222,7 @@ nodeSendActions nodeUnit packing =
                 let msgName = messageName (Proxy :: Proxy snd)
                     cactions :: ConversationActions snd rcv m
                     cactions = nodeConversationActions nodeUnit nodeId packing inchan outchan
-                LL.writeChannel outchan . LBS.toChunks $ packMsg packing msgName
+                LL.writeMany mtu outchan (packMsg packing msgName)
                 converse cactions
 
 -- | Conversation actions for a given peer and in/out channels.
@@ -210,8 +230,8 @@ nodeConversationActions
     :: forall packing peerData snd rcv m .
        ( Mockable Throw m, Mockable Channel.Channel m, Mockable SharedExclusive m
        , WithLogger m
-       , Packable packing snd
-       , Unpackable packing rcv
+       , Serializable packing snd
+       , Serializable packing rcv
        )
     => LL.Node packing peerData m
     -> LL.NodeId
@@ -224,15 +244,13 @@ nodeConversationActions _ _ packing inchan outchan =
     where
 
     nodeSend = \body -> do
-        LL.writeChannel outchan . LBS.toChunks $ packMsg packing body
+        LL.writeMany mtu outchan (packMsg packing body)
 
-    nodeRecv = do
-        next <- recvNext inchan packing
+    nodeRecv :: Word32 -> m (Maybe rcv)
+    nodeRecv limit = do
+        next <- recvNext packing (fromIntegral limit :: Int) inchan
         case next of
             End     -> pure Nothing
-            NoParse -> do
-                logDebug "Unexpected end of conversation input"
-                pure Nothing
             Input t -> pure (Just t)
 
 data NodeAction packing peerData m t =
@@ -333,10 +351,9 @@ node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
         -> m ()
     handlerInOut nodeUnit listenerIndices peerData peerId inchan outchan = do
         let listenerIndex = listenerIndices peerData
-        input <- recvNext inchan packing
+        input <- recvNext packing messageSizeLimit inchan
         case input of
             End -> logDebug "handlerInOut : unexpected end of input"
-            NoParse -> logDebug "handlerInOut : failed to parse message name"
             Input msgName -> do
                 let listener = M.lookup msgName listenerIndex
                 case listener of
@@ -344,30 +361,48 @@ node mkEndPoint mkReceiveDelay prng packing peerData nodeEnv k = do
                         let cactions = nodeConversationActions nodeUnit peerId packing inchan outchan
                         in  action peerData peerId cactions
                     Nothing -> error ("handlerInOut : no listener for " ++ show msgName)
+    -- Arbitrary limit on the message size...
+    -- TODO make it configurable I guess.
+    messageSizeLimit :: Int
+    messageSizeLimit = 256
 
+-- | Try to receive and parse the next message, subject to a limit on the
+--   number of bytes which will be read.
 recvNext
     :: ( Mockable Channel.Channel m
-       , Unpackable packing thing
-       , WithLogger m)
-    => ChannelIn m
-    -> packing
+       , Mockable Throw m
+       , Serializable packing thing
+       )
+    => packing
+    -> Int
+    -> ChannelIn m
     -> m (Input thing)
-recvNext (LL.ChannelIn channel) packing = do
+recvNext packing limit (LL.ChannelIn channel) = do
+    -- Check whether the channel is depleted and End if so. Otherwise, push
+    -- the bytes into the type's decoder and try to parse it before reaching
+    -- the byte limit.
     mbs <- Channel.readChannel channel
     case mbs of
         Nothing -> return End
         Just bs -> do
-            (trailing, outcome) <- go (Bin.pushChunk (unpackMsg packing) bs)
+            -- limit' is the number of bytes that 'go' is allowed to pull.
+            -- It's assumed that reading from the channel will bring in at most
+            -- some limited number of bytes, so 'go' may bring in at most this
+            -- many more than the limit.
+            let limit' = limit - BS.length bs
+            (trailing, outcome) <- go limit' (continueDecoding (unpackMsg packing) [bs])
             unless (BS.null trailing) (Channel.unGetChannel channel (Just trailing))
             return outcome
-    where
-    go decoder = case decoder of
-        Bin.Fail trailing _ err ->
-            logError (sformat ("recvNext: Decoding failed " % shown) err)
-            >> return (trailing, NoParse)
-        Bin.Done trailing _ thing -> return (trailing, Input thing)
-        Bin.Partial next -> do
+  where
+    go remaining decoder = case decoder of
+        -- TODO use the error message in the exception.
+        Fail _ _ _ -> throw NoParse
+        Done trailing _ thing -> return (trailing, Input thing)
+        Partial next -> do
+            when (remaining <= 0) (throw LimitExceeded)
             mbs <- Channel.readChannel channel
             case mbs of
                 Nothing -> return (BS.empty, End)
-                Just bs -> go (next (Just bs))
+                Just bs ->
+                    let !remaining' = remaining - BS.length bs
+                    in  go remaining' (next (Just bs))

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -154,6 +154,9 @@ data ConversationActions body rcv m = ConversationActions {
 
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).
+       --   The 'Word32' parameter is a limit on how many bytes will be read
+       --   in by this use of 'recv'. If the limit is exceeded, the
+       --   'LimitExceeded' exception is thrown.
      , recv :: Word32 -> m (Maybe rcv)
      }
 

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -164,13 +164,18 @@ makeSomeHandler promise = do
     return $ SomeHandler tid promise
 
 data NodeEnvironment (m :: * -> *) = NodeEnvironment {
-      nodeAckTimeout :: Microsecond
+      nodeAckTimeout :: !Microsecond
+      -- | Maximum transmission unit: how many bytes can be sent in a single
+      --   network-transport send. Tune this according to the transport
+      --   which backs the time-warp node.
+    , nodeMtu        :: !Word32
     }
 
 defaultNodeEnvironment :: NodeEnvironment m
 defaultNodeEnvironment = NodeEnvironment {
       -- 30 second timeout waiting for an ACK.
       nodeAckTimeout = 30000000
+    , nodeMtu        = maxBound
     }
 
 -- | Computation in m of a delay (or no delay).

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -41,7 +41,7 @@ module Node.Internal (
     stopNode,
     withOutChannel,
     withInOutChannel,
-    writeChannel,
+    writeMany,
     Timeout(..)
   ) where
 
@@ -49,8 +49,7 @@ import           Control.Exception             hiding (bracket, catch, finally, 
 import           Control.Monad                 (forM_, forM, when)
 import           Control.Monad.Fix             (MonadFix)
 import           Data.Int                      (Int64)
-import           Data.Binary                   as Bin
-import           Data.Binary.Get               as Bin
+import           Data.Binary
 import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Builder       as BS
 import qualified Data.ByteString.Builder.Extra as BS
@@ -76,11 +75,12 @@ import           Mockable.SharedAtomic
 import           Mockable.SharedExclusive
 import           Mockable.CurrentTime          (CurrentTime, currentTime)
 import qualified Mockable.Metrics              as Metrics
-import qualified Network.Transport             as NT (EventErrorCode (EventConnectionLost, EventEndPointFailed, EventTransportFailed))
+import qualified Network.Transport             as NT (EventErrorCode (..))
 import qualified Network.Transport.Abstract    as NT
 import           System.Random                 (Random, StdGen, random)
 import           System.Wlog                   (WithLogger, logDebug, logError, logWarning)
-import qualified Node.Message                  as Message
+import           Node.Message.Class            (Serializable (..))
+import           Node.Message.Decoder          (Decoder (..), continueDecoding)
 
 -- | A 'NodeId' wraps a network-transport endpoint address
 newtype NodeId = NodeId NT.EndPointAddress
@@ -237,20 +237,26 @@ newtype ChannelOut m = ChannelOut (NT.Connection m)
 closeChannel :: ChannelOut m -> m ()
 closeChannel (ChannelOut conn) = NT.close conn
 
--- | Write some ByteStrings to an out channel. It does not close the
---   transport when finished. If you want that, use withOutChannel or
---   withInOutChannel.
-writeChannel
-    :: ( Monad m, WithLogger m, Mockable Throw m )
-    => ChannelOut m
-    -> [BS.ByteString]
+-- | Do multiple sends on a 'ChannelOut'.
+writeMany
+    :: ( Monad m, Mockable Throw m )
+    => Word32 -- ^ Split into chunks of at most this size in bytes. 0 means no split.
+    -> ChannelOut m
+    -> LBS.ByteString
     -> m ()
-writeChannel (ChannelOut conn) chunks = do
-    res <- NT.send conn chunks
-    -- TBD error handling? Throw exception or report it as a Left?
-    case res of
-      Left err -> throw err
-      Right _  -> pure ()
+writeMany mtu (ChannelOut conn) bss =
+    NT.send conn (chop bss >>= LBS.toChunks) >>= either throw pure
+  where
+    chop :: LBS.ByteString -> [LBS.ByteString]
+    chop | mtu == 0 = pure
+         | otherwise =
+               let mtuInt :: Int64
+                   mtuInt = fromIntegral mtu
+                   chopItUp lbs | LBS.null lbs = []
+                                | otherwise =
+                                      let (front, back) = LBS.splitAt mtuInt lbs
+                                      in  front : chop back
+               in  chopItUp
 
 -- | Statistics concerning traffic at this node.
 data Statistics m = Statistics {
@@ -586,14 +592,15 @@ simpleNodeEndPoint transport = NodeEndPoint {
 
 -- | Bring up a 'Node' using a network transport.
 startNode
-    :: ( Mockable SharedAtomic m, Mockable Channel.Channel m
+    :: forall packingType peerData m .
+       ( Mockable SharedAtomic m, Mockable Channel.Channel m
        , Mockable Bracket m, Mockable Throw m, Mockable Catch m
        , Mockable Async m, Mockable Concurrently m
        , Ord (ThreadId m), Show (ThreadId m)
        , Mockable CurrentTime m, Mockable Metrics.Metrics m
        , Mockable SharedExclusive m
        , Mockable Delay m
-       , Message.Serializable packingType peerData
+       , Serializable packingType peerData
        , MonadFix m, WithLogger m )
     => packingType
     -> peerData
@@ -699,7 +706,7 @@ data PeerState peerData =
       --   connection which has given a partial parse of the peer data.
       ExpectingPeerData
           !(NonEmptySet NT.ConnectionId)
-          !(Maybe (NT.ConnectionId, Maybe BS.ByteString -> Bin.Decoder peerData))
+          !(Maybe (NT.ConnectionId, Maybe BS.ByteString -> Decoder peerData))
 
       -- | Peer data has been received and parsed.
     | GotPeerData !peerData !(NonEmptySet NT.ConnectionId)
@@ -762,7 +769,7 @@ nodeDispatcher
        , Mockable Channel.Channel m, Mockable Throw m, Mockable Catch m
        , Mockable CurrentTime m, Mockable Metrics.Metrics m
        , Mockable Delay m
-       , Message.Serializable packingType peerData
+       , Serializable packingType peerData
        , MonadFix m, WithLogger m, Show (ThreadId m) )
     => Node packingType peerData m
     -> (peerData -> NodeId -> ChannelIn m -> ChannelOut m -> m ())
@@ -926,20 +933,20 @@ nodeDispatcher node handlerInOut =
                 -- There's no leader. This connection is now the leader. Begin
                 -- the attempt to decode the peer data.
                 Nothing -> do
-                    let decoder :: Bin.Decoder peerData
-                        decoder = Message.unpackMsg (nodePackingType node)
-                    case Bin.pushChunk decoder (BS.concat chunks) of
-                        Bin.Fail _ _ err -> do
+                    let decoder :: Decoder peerData
+                        decoder = unpackMsg (nodePackingType node)
+                    case continueDecoding decoder chunks of
+                        Fail _ _ err -> do
                             logWarning $ sformat ("failed to decode peer data from " % shown % ": got error " % shown) peer err
                             return $ state {
                                     dsConnections = Map.insert connid (peer, PeerDataParseFailure) (dsConnections state)
                                   }
-                        Bin.Done trailing _ peerData -> do
+                        Done trailing _ peerData -> do
                             return $ state {
                                     dsConnections = foldl' (awaitHandshake connid peerData trailing) (dsConnections state) (NESet.toList connids)
                                   , dsPeers = Map.insert peer (GotPeerData peerData connids) (dsPeers state)
                                   }
-                        Bin.Partial decoderContinuation -> do
+                        Partial decoderContinuation -> do
                             return $ state {
                                     dsPeers = Map.insert peer (ExpectingPeerData connids (Just (connid, decoderContinuation))) (dsPeers state)
                                   }
@@ -954,19 +961,19 @@ nodeDispatcher node handlerInOut =
 
                     True -> case decoderContinuation (Just (BS.concat chunks)) of
 
-                        Bin.Fail _ _ err -> do
+                        Fail _ _ err -> do
                             logWarning $ sformat ("failed to decode peer data from " % shown % ": got error " % shown) peer err
                             return $ state {
                                     dsConnections = Map.insert connid (peer, PeerDataParseFailure) (dsConnections state)
                                   }
 
-                        Bin.Done trailing _ peerData -> do
+                        Done trailing _ peerData -> do
                             return $ state {
                                     dsConnections = foldl' (awaitHandshake connid peerData trailing) (dsConnections state) (NESet.toList connids)
                                   , dsPeers = Map.insert peer (GotPeerData peerData connids) (dsPeers state)
                                   }
 
-                        Bin.Partial decoderContinuation' -> do
+                        Partial decoderContinuation' -> do
                             return $ state {
                                     dsPeers = Map.insert peer (ExpectingPeerData connids (Just (connid, decoderContinuation'))) (dsPeers state)
 
@@ -1046,9 +1053,9 @@ nodeDispatcher node handlerInOut =
                                             respondAndHandle
                           -- Establish the other direction in a separate thread.
                           (_, incrBytes) <- spawnHandler nstate provenance handler
-                          let bss = LBS.toChunks ws'
-                          Channel.writeChannel channel (Just (BS.concat bss))
-                          incrBytes $ sum (fmap BS.length bss)
+                          let bs = LBS.toStrict ws'
+                          Channel.writeChannel channel (Just bs)
+                          incrBytes $ fromIntegral (BS.length bs)
                           return $ state {
                                 dsConnections = Map.insert connid (peer, FeedingApplicationHandler (ChannelIn channel) incrBytes) (dsConnections state)
                               }
@@ -1099,7 +1106,7 @@ nodeDispatcher node handlerInOut =
                                   putSharedExclusive peerDataVar peerData
                                   let bs = LBS.toStrict ws'
                                   Channel.writeChannel channel (Just bs)
-                                  incrBytes $ BS.length bs
+                                  incrBytes $ fromIntegral (BS.length bs)
                                   return $ state {
                                         dsConnections = Map.insert connid (peer, FeedingApplicationHandler (ChannelIn channel) incrBytes) (dsConnections state)
                                       }
@@ -1117,8 +1124,9 @@ nodeDispatcher node handlerInOut =
         -- explcitly close it down when the handler finishes by adding some
         -- mutable cell to FeedingApplicationHandler?
         Just (_peer, FeedingApplicationHandler (ChannelIn channel) incrBytes) -> do
-            Channel.writeChannel channel (Just (BS.concat chunks))
-            incrBytes $ sum (fmap BS.length chunks)
+            let bs = LBS.toStrict (LBS.fromChunks chunks)
+            Channel.writeChannel channel (Just bs)
+            incrBytes $ BS.length bs
             return state
 
     connectionClosed
@@ -1337,19 +1345,22 @@ controlHeaderUnidirectional =
 
 controlHeaderBidirectionalSyn :: Nonce -> BS.ByteString
 controlHeaderBidirectionalSyn (Nonce nonce) =
-    fixedSizeBuilder 9 $
+    fixedSizeBuilder' 9 $
         BS.word8 controlHeaderCodeBidirectionalSyn
      <> BS.word64BE nonce
 
 controlHeaderBidirectionalAck :: Nonce -> BS.ByteString
 controlHeaderBidirectionalAck (Nonce nonce) =
-    fixedSizeBuilder 9 $
+    fixedSizeBuilder' 9 $
         BS.word8 controlHeaderCodeBidirectionalAck
      <> BS.word64BE nonce
 
-fixedSizeBuilder :: Int -> BS.Builder -> BS.ByteString
+fixedSizeBuilder' :: Int -> BS.Builder -> BS.ByteString
+fixedSizeBuilder' n = LBS.toStrict . fixedSizeBuilder n
+
+fixedSizeBuilder :: Int -> BS.Builder -> LBS.ByteString
 fixedSizeBuilder n =
-    LBS.toStrict . BS.toLazyByteStringWith (BS.untrimmedStrategy n n) LBS.empty
+    BS.toLazyByteStringWith (BS.untrimmedStrategy n n) LBS.empty
 
 -- | Create, use, and tear down a conversation channel with a given peer
 --   (NodeId).
@@ -1364,7 +1375,7 @@ withInOutChannel
        , Mockable CurrentTime m, Mockable Metrics.Metrics m
        , Mockable Delay m
        , MonadFix m, WithLogger m
-       , Message.Packable packingType peerData )
+       , Serializable packingType peerData )
     => Node packingType peerData m
     -> NodeId
     -> (peerData -> ChannelIn m -> ChannelOut m -> m a)
@@ -1422,7 +1433,7 @@ withOutChannel
        , Mockable SharedExclusive m
        , Mockable Metrics.Metrics m
        , MonadFix m, WithLogger m
-       , Message.Packable packingType peerData )
+       , Serializable packingType peerData )
     => Node packingType peerData m
     -> NodeId
     -> (ChannelOut m -> m a)
@@ -1571,7 +1582,7 @@ connectToPeer
        , Mockable Bracket m
        , Mockable SharedAtomic m
        , Mockable SharedExclusive m
-       , Message.Packable packingType peerData
+       , Serializable packingType peerData
        , WithLogger m
        )
     => Node packingType peerData m
@@ -1596,7 +1607,7 @@ connectToPeer Node{nodeEndPoint, nodeState, nodePackingType, nodePeerData} (Node
         True -> sendPeerData conn
 
     sendPeerData conn = do
-        let serializedPeerData = Message.packMsg nodePackingType nodePeerData
+        let serializedPeerData = packMsg nodePackingType nodePeerData
         outcome <- NT.send conn (LBS.toChunks serializedPeerData)
         case outcome of
             Left err -> do
@@ -1775,7 +1786,7 @@ connectOutChannel
        , Mockable Bracket m
        , Mockable SharedAtomic m
        , Mockable SharedExclusive m
-       , Message.Packable packingType peerData
+       , Serializable packingType peerData
        , WithLogger m
        )
     => Node packingType peerData m

--- a/src/Node/Message/Binary.hs
+++ b/src/Node/Message/Binary.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Node.Message.Binary
+    ( BinaryP (..)
+    , binaryPackMsg
+    , binaryUnpackMsg
+    ) where
+
+import qualified Data.Binary                   as Bin
+import qualified Data.Binary.Put               as Bin
+import qualified Data.Binary.Get               as Bin
+import qualified Data.ByteString.Builder.Extra as BS
+import qualified Data.ByteString.Lazy          as LBS
+import qualified Data.Text                     as T
+import           Node.Message.Decoder          (Decoder (..))
+import           Node.Message.Class            (Serializable (..))
+
+data BinaryP = BinaryP
+
+binaryPackMsg :: Bin.Binary t => t -> LBS.ByteString
+binaryPackMsg =
+    BS.toLazyByteStringWith
+        (BS.untrimmedStrategy 256 4096)
+        LBS.empty
+    . Bin.execPut
+    . Bin.put
+
+binaryUnpackMsg :: Bin.Binary t => Decoder t
+binaryUnpackMsg = fromBinaryDecoder (Bin.runGetIncremental Bin.get)
+
+fromBinaryDecoder :: Bin.Decoder t -> Decoder t
+fromBinaryDecoder (Bin.Done bs bo t) = Done bs bo t
+fromBinaryDecoder (Bin.Fail bs bo err) = Fail bs bo (T.pack err)
+fromBinaryDecoder (Bin.Partial k) = Partial (fromBinaryDecoder . k)
+
+-- TBD some way to make custom serialization strategies.
+-- Perhaps a new typeclass
+--
+--   Bin.Binary t => BinarySerializable t
+--
+-- with default binary packing/unpacking functions.
+instance Bin.Binary t => Serializable BinaryP t where
+    packMsg _ = binaryPackMsg
+    unpackMsg _ = binaryUnpackMsg

--- a/src/Node/Message/Class.hs
+++ b/src/Node/Message/Class.hs
@@ -9,24 +9,18 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-module Node.Message
-    ( Packable (..)
-    , Unpackable (..)
-    , Serializable
-    , Bin.Decoder(..)
+module Node.Message.Class
+    ( Serializable (..)
 
     , Message (..)
     , messageName'
 
     , MessageName (..)
-    , BinaryP (..)
     ) where
 
 import qualified Data.Binary                   as Bin
-import qualified Data.Binary.Get               as Bin
-import qualified Data.Binary.Put               as Bin
+import qualified Data.Store                    as Store
 import qualified Data.ByteString               as BS
-import qualified Data.ByteString.Builder.Extra as BS
 import qualified Data.ByteString.Lazy          as LBS
 import           Data.Data                     (Data, dataTypeName, dataTypeOf)
 import           Data.Hashable                 (Hashable)
@@ -38,6 +32,7 @@ import qualified Data.Text.Buildable           as B
 import qualified Formatting                    as F
 import           GHC.Generics                  (Generic)
 import           Serokell.Util.Base16          (base16F)
+import           Node.Message.Decoder          (Decoder)
 
 -- * Message name
 
@@ -50,6 +45,7 @@ deriving instance IsString MessageName
 deriving instance Hashable MessageName
 deriving instance Monoid MessageName
 instance Bin.Binary MessageName
+instance Store.Store MessageName
 
 instance Buildable MessageName where
     build (MessageName mn) = F.bprint base16F mn
@@ -75,34 +71,11 @@ messageName' = messageName . proxyOf
     proxyOf :: a -> Proxy a
     proxyOf _ = Proxy
 
--- * Serialization strategy
-
 -- | Defines a way to serialize object @r@ with given packing type @p@.
-class Packable packing thing where
+--
+-- TODO should use a proxy on packing rather than a value, no?
+class Serializable packing thing where
     -- | Way of packing data to raw bytes.
-    -- TODO: use Data.ByteString.Builder?
     packMsg :: packing -> thing -> LBS.ByteString
-
--- | Defines a way to deserealize data with given packing type @p@ and extract object @t@.
-class Unpackable packing thing where
-    unpackMsg :: packing -> Bin.Decoder thing
-
-type Serializable packing thing =
-    ( Packable packing thing
-    , Unpackable packing thing
-    )
-
--- * Default instances
-
-data BinaryP = BinaryP
-
-instance Bin.Binary t => Packable BinaryP t where
-    packMsg _ t =
-        BS.toLazyByteStringWith
-            (BS.untrimmedStrategy 256 4096)
-            LBS.empty
-        . Bin.execPut
-        $ Bin.put t
-
-instance Bin.Binary t => Unpackable BinaryP t where
-    unpackMsg _ = Bin.runGetIncremental Bin.get
+    -- | Incrementally unpack.
+    unpackMsg :: packing -> Decoder thing

--- a/src/Node/Message/Decoder.hs
+++ b/src/Node/Message/Decoder.hs
@@ -1,0 +1,25 @@
+module Node.Message.Decoder
+    ( Decoder (..)
+    , ByteOffset
+    , continueDecoding
+    ) where
+
+import           Data.Int         (Int64)
+import qualified Data.ByteString  as BS
+import qualified Data.Text        as T
+
+type ByteOffset = Int64
+
+data Decoder t =
+      Done !BS.ByteString !ByteOffset !t
+    | Fail !BS.ByteString !ByteOffset !T.Text
+    | Partial (Maybe BS.ByteString -> Decoder t)
+
+continueDecoding
+    :: Decoder t
+    -> [BS.ByteString]
+    -> Decoder t
+continueDecoding decoder bss = case decoder of
+    Done trailing offset t -> Done (BS.concat $ trailing : bss) offset t
+    Fail trailing offset err -> Fail (BS.concat $ trailing : bss) offset err
+    Partial k -> k $ Just (BS.concat bss)

--- a/src/Node/Message/Store.hs
+++ b/src/Node/Message/Store.hs
@@ -37,6 +37,8 @@ storeDecoder bs = Partial $ \mbs -> case mbs of
         let (front, back) = BS.splitAt 4 (BS.append bs bs')
         in  if BS.length front == 4
             then storeDecoderBody (NT.decodeWord32 front) BS.empty (Just back)
+            -- In this case, back is empty and front has length strictly less
+            -- than 4, so we have to wait for more input.
             else storeDecoder front
 
 storeDecoderBody

--- a/src/Node/Message/Store.hs
+++ b/src/Node/Message/Store.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE OverloadedStrings     #-}
+
+module Node.Message.Store
+    ( StoreP (..)
+    ) where
+
+import qualified Data.Store                    as Store
+import qualified Data.ByteString               as BS
+import qualified Data.ByteString.Lazy          as LBS
+import           Data.Word                     (Word32)
+import qualified Network.Transport.Internal    as NT (encodeWord32, decodeWord32)
+import           Node.Message.Class            (Serializable (..))
+import           Node.Message.Decoder          (Decoder (..))
+
+data StoreP = StoreP
+
+instance Store.Store t => Serializable StoreP t where
+
+    -- Length-prefix the store-encoded body. The length is assumed to fit into
+    -- 32 bits.
+    packMsg _ t = encoded
+      where
+        encodedBody = Store.encode t
+        encodedLength = NT.encodeWord32 (fromIntegral (BS.length encodedBody))
+        encoded = LBS.fromStrict (BS.append encodedLength encodedBody)
+
+    unpackMsg _ = storeDecoder BS.empty
+
+storeDecoder :: Store.Store t => BS.ByteString -> Decoder t
+storeDecoder bs = Partial $ \mbs -> case mbs of
+    Nothing -> Fail BS.empty (fromIntegral (BS.length bs)) "Unexpected end of input (length prefix)"
+    Just bs' ->
+        let (front, back) = BS.splitAt 4 (BS.append bs bs')
+        in  if BS.length front == 4
+            then storeDecoderBody (NT.decodeWord32 front) BS.empty (Just back)
+            else storeDecoder front
+
+storeDecoderBody
+    :: ( Store.Store t )
+    => Word32
+    -> BS.ByteString
+    -> Maybe BS.ByteString
+    -> Decoder t
+storeDecoderBody !remaining !acc !mbs = case mbs of
+    Nothing -> Fail BS.empty (fromIntegral (BS.length acc)) "Unexpected end of input (body)"
+    Just bs ->
+        let (front, back) = BS.splitAt (fromIntegral remaining) bs
+            taken = fromIntegral (BS.length front)
+            acc' = BS.append acc front
+            remaining' = remaining - taken
+        in  if taken < remaining
+            then Partial $ storeDecoderBody remaining' acc'
+            else case Store.decode acc' of
+                Left ex -> Fail back (fromIntegral (BS.length acc')) (Store.peekExMessage ex)
+                Right t -> Done back (fromIntegral (BS.length acc')) t

--- a/stack.yaml
+++ b/stack.yaml
@@ -27,6 +27,7 @@ extra-deps:
   - time-units-1.0.0
   - log-warper-1.0.2
   - universum-0.3
+  - store-0.4.3.1
 
 flags: {}
 extra-package-dbs: []

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -51,6 +51,7 @@ import qualified Data.ByteString             as LBS
 import qualified Data.List                   as L
 import qualified Data.Set                    as S
 import           Data.Time.Units             (Microsecond, Millisecond, Second, TimeUnit)
+import           Data.Word                   (Word32)
 import           GHC.Generics                (Generic)
 import           Mockable.Class              (Mockable)
 import           Mockable.Concurrent         (delay, forConcurrently, fork, cancel,
@@ -272,12 +273,14 @@ makeTCPTransport
     -> String
     -> String
     -> (forall t . IO (TCP.QDisc t))
+    -> Word32
     -> IO NT.Transport
-makeTCPTransport bind hostAddr port qdisc = do
+makeTCPTransport bind hostAddr port qdisc mtu = do
     let tcpParams = TCP.defaultTCPParameters {
               TCP.tcpReuseServerAddr = True
             , TCP.tcpReuseClientAddr = True
             , TCP.tcpNewQDisc = qdisc
+            , TCP.tcpMaxReceiveLength = mtu
             }
     choice <- TCP.createTransport (TCP.Addressable (TCP.TCPAddrInfo bind port ((,) hostAddr))) tcpParams
     case choice of

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -80,7 +80,7 @@ import           Node                        (ConversationActions (..), Listener
                                               Worker, node, nodeId, defaultNodeEnvironment,
                                               simpleNodeEndPoint, Conversation (..),
                                               noReceiveDelay)
-import           Node.Message                (BinaryP (..))
+import           Node.Message.Binary         (BinaryP (..))
 
 -- | Run a computation, but kill it if it takes more than a given number of
 --   Microseconds to complete. If that happens, log using a given string
@@ -236,7 +236,7 @@ sendAll ConversationStyle sendActions peerId msgs =
             Conversation $ \cactions -> forM_ msgs $
                 \msg -> do
                     send cactions msg
-                    (_ :: Maybe Bool) <- recv cactions
+                    (_ :: Maybe Bool) <- recv cactions maxBound
                     pure ()
 
 receiveAll
@@ -255,7 +255,7 @@ receiveAll
 -- sender doesn't finish before the conversation SYN/ACK completes.
 receiveAll ConversationStyle  handler =
     ListenerActionConversation @_ @_ @_ @Bool $ \_ _ cactions ->
-        let loop = do mmsg <- recv cactions
+        let loop = do mmsg <- recv cactions maxBound
                       case mmsg of
                           Nothing -> pure ()
                           Just msg -> do


### PR DESCRIPTION
- Outgoing messages are split into chunks of at most some number of
  bytes. This value must be properly configured when running over
  network-transport-tcp, to be smaller than the maximum receive size.
- Node.Message has been split up and the Packable/Unpackable classes
  rolled into one class Serializable, which demands an incremental
  decoder which mimics the on from Data.Binary.Get
- In a conversation, 'recv' takes a limit on the number of bytes which
  will be read.
- Can use store instead of binary for deserialization, as shown in the
  implementation of Node.Message.Store

TODO: give a CBOR-backed implementation and use criterion to get some real
performance numbers.