### PR TITLE
[CSL-738] Use most typical monad constraints in NTP

### DIFF
--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -1,5 +1,5 @@
 name:                node-sketch
-version:             0.1.2.0
+version:             0.1.2.1
 license:             MIT
 license-file:        LICENSE
 category:            Network

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -61,6 +61,7 @@ Library
                       , hashable
                       , kademlia
                       , lens
+                      , lifted-base
                       , log-warper
                       , mmorph
                       , monad-control


### PR DESCRIPTION
This is part of planned efforts to temporally get rid of
`Mockable Throw` & `Mockable Catch` usages.

Also `MonadMask` is removed, since `bracketOnError` can be performed
in terms of `MonadBaseControl IO`.