### PR TITLE
Bump Kademlia version

### DIFF
--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -87,8 +87,8 @@ makeNode transport i = do
             if i == 0
             -- First node uses itself as initial peer, else it'll panic because
             -- its initial peer appears to be down.
-            then K.Node (K.Peer host (fromIntegral port)) anId
-            else K.Node (K.Peer host (fromIntegral (port - 1))) (makeId (i - 1))
+            then K.Peer host (fromIntegral port)
+            else K.Peer host (fromIntegral (port - 1))
     let kademliaConfig = K.KademliaConfiguration host (fromIntegral port) anId
     let prng1 = mkStdGen (2 * i)
     let prng2 = mkStdGen ((2 * i) + 1)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -81,17 +81,18 @@ makeNode :: Transport Production
          -> Production (ThreadId Production)
 makeNode transport i = do
     let port = 3000 + i
-    let host = "127.0.0.1"
-    let anId = makeId i
-    let initialPeer =
+        host = "127.0.0.1"
+        addr = (host, fromIntegral port)
+        anId = makeId i
+        initialPeer =
             if i == 0
             -- First node uses itself as initial peer, else it'll panic because
             -- its initial peer appears to be down.
             then K.Peer host (fromIntegral port)
             else K.Peer host (fromIntegral (port - 1))
-    let kademliaConfig = K.KademliaConfiguration host (fromIntegral port) anId
-    let prng1 = mkStdGen (2 * i)
-    let prng2 = mkStdGen ((2 * i) + 1)
+        kademliaConfig = K.KademliaConfiguration addr addr anId
+        prng1 = mkStdGen (2 * i)
+        prng2 = mkStdGen ((2 * i) + 1)
     liftIO . putStrLn $ "Starting node " ++ show i
     fork $ node (simpleNodeEndPoint transport) (const noReceiveDelay) prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do

--- a/src/Network/Discovery/Transport/Kademlia.hs
+++ b/src/Network/Discovery/Transport/Kademlia.hs
@@ -9,7 +9,6 @@ module Network.Discovery.Transport.Kademlia
        , kademliaDiscovery
        ) where
 
-import           Control.Arrow               (second)
 import qualified Control.Concurrent.STM      as STM
 import qualified Control.Concurrent.STM.TVar as TVar
 import           Control.Monad               (forM)
@@ -71,8 +70,8 @@ kademliaDiscovery configuration peer myAddress = do
         kid = KSerialize (kademliaId configuration)
     -- A Kademlia instance to do the DHT magic.
     kademliaInst :: K.KademliaInstance (KSerialize i) (KSerialize EndPointAddress)
-        <- liftIO $ K.create (second fromIntegral $ kademliaBindAddress configuration)
-                             (second fromIntegral $ kademliaExternalAddress configuration) kid
+        <- liftIO $ K.create (kademliaBindAddress configuration)
+                             (kademliaExternalAddress configuration) kid
     -- A TVar to cache the set of known peers at the last use of 'discoverPeers'
     peersTVar :: TVar.TVar (M.Map (K.Node (KSerialize i)) EndPointAddress)
         <- liftIO . TVar.newTVarIO $ M.empty

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
   - '.'
   - location:
       git: https://github.com/serokell/kademlia.git
-      commit: b4b0a6774368b9bbea96d7a03a1a451b6fc3cfea
+      commit: f7b29ff0994dfd46a3731460946c8d2666179ac2
     extra-dep: true
   - location:
       git: https://github.com/serokell/network-transport

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
   - '.'
   - location:
       git: https://github.com/serokell/kademlia.git
-      commit: f7b29ff0994dfd46a3731460946c8d2666179ac2
+      commit: 7a0ecf003dc2d45c05d7e61d4ddcca9d14a155c4
     extra-dep: true
   - location:
       git: https://github.com/serokell/network-transport

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
   - '.'
   - location:
       git: https://github.com/serokell/kademlia.git
-      commit: 7a0ecf003dc2d45c05d7e61d4ddcca9d14a155c4
+      commit: 92043c7e80e93aeb08212e8ce42c783edd9b2f80
     extra-dep: true
   - location:
       git: https://github.com/serokell/network-transport


### PR DESCRIPTION
The branch used by cardano-sl uses a special Kademlia revision that takes an external host address in addition to the bind address.

I'm fairly confident this Kademlia change isn't needed. The external address is only ever given to peers who already know this node's external address, so why bother?

But anyway, the revision is used by cardano-sl, so if we want to build that against time-warp master then we have to update time-warp to use it. We're going to port all mentions of Kademlia out of cardano-sl and here to time-warp and this is the first step.