### PR TITLE
[CSL-1154] JsonLogConfig type

### DIFF
--- a/src/JsonLog/CanJsonLog.hs
+++ b/src/JsonLog/CanJsonLog.hs
@@ -44,8 +44,8 @@ class Monad m => CanJsonLog m where
     default jsonLog :: ( CanJsonLog n
                        , MonadTrans t
                        , m ~ t n
-                       , ToJSON a) 
-                    => a 
+                       , ToJSON a)
+                    => a
                     -> m ()
     jsonLog x = lift $ jsonLog x
 
@@ -56,8 +56,7 @@ instance (Monoid w, CanJsonLog m) => CanJsonLog (WriterT w m)
 instance CanJsonLog m => CanJsonLog (LoggerNameBox m)
 instance CanJsonLog m => CanJsonLog (ResourceT m)
 
-deriving instance CanJsonLog m => CanJsonLog (TaggedTrans tag IdentityT m)
-deriving instance CanJsonLog m => CanJsonLog (TaggedTrans tag (ReaderT a) m)
+deriving instance CanJsonLog (t m) => CanJsonLog (TaggedTrans tag t m)
 
 -- | @'jsonLogWrappedM'@ is a convenience default implementation
 -- of @'jsonLog'@ to facilitate providing instances of class @'CanJsonLog'@

--- a/src/JsonLog/JsonLogT.hs
+++ b/src/JsonLog/JsonLogT.hs
@@ -24,18 +24,20 @@ module JsonLog.JsonLogT
     , runJsonLogT'
     , runWithJsonLogT
     , runWithJsonLogT'
+    , JsonLogConfig(..)
+    , jsonLogDefault
     ) where
 
 import Control.Concurrent.MVar        (MVar, withMVar)
 import Control.Monad.Base             (MonadBase)
 import Control.Monad.Fix              (MonadFix)
 import Control.Monad.IO.Class         (MonadIO (..))
-import Control.Monad.Morph            (MFunctor (..)) 
+import Control.Monad.Morph            (MFunctor (..))
 import Control.Monad.Trans.Class      (MonadTrans)
 import Control.Monad.Trans.Control    (MonadBaseControl (..))
 import Control.Monad.Trans.Lift.Local (LiftLocal)
 import Control.Monad.Trans.Reader     (ReaderT (..))
-import Data.Aeson                     (encode)
+import Data.Aeson                     (ToJSON, encode)
 import Data.ByteString.Lazy           (hPut)
 import Formatting                     (sformat, shown, (%))
 import Serokell.Util.Lens             (WrappedM (..))
@@ -56,12 +58,14 @@ import Mockable.Metrics               (Gauge, Counter, Distribution, Metrics)
 import Mockable.SharedAtomic          (SharedAtomicT, SharedAtomic)
 import Mockable.SharedExclusive       (SharedExclusiveT, SharedExclusive)
 
-type R = Maybe (MVar Handle, JLTimedEvent -> IO Bool)
+data JsonLogConfig
+    = JsonLogDisabled
+    | JsonLogConfig (MVar Handle) (JLTimedEvent -> IO Bool)
 
 -- | Monad transformer @'JsonLogT'@ adds support for JSON logging
 -- to a monad transformer stack.
-newtype JsonLogT m a = JsonLogT (ReaderT R m a)
-    deriving (Functor, Applicative, Monad, MonadTrans, MonadIO, MFunctor, 
+newtype JsonLogT m a = JsonLogT (ReaderT JsonLogConfig m a)
+    deriving (Functor, Applicative, Monad, MonadTrans, MonadIO, MFunctor,
               MonadThrow, MonadCatch, MonadMask, MonadFix, MonadBase b, LiftLocal)
 
 instance MonadBaseControl b m => MonadBaseControl b (JsonLogT m) where
@@ -82,7 +86,7 @@ instance WithLogger m => HasLoggerName (JsonLogT m) where
 
 instance Monad m => WrappedM (JsonLogT m) where
 
-    type UnwrappedM (JsonLogT m) = ReaderT R m
+    type UnwrappedM (JsonLogT m) = ReaderT JsonLogConfig m
 
     unpackM = JsonLogT
 
@@ -146,65 +150,70 @@ instance Mockable Metrics m => Mockable Metrics (JsonLogT m) where
 
     liftMockable = liftMockableWrappedM
 
+jsonLogDefault
+    :: (ToJSON a, Mockable Catch m, MonadIO m, WithLogger m)
+    => JsonLogConfig
+    -> a -> m ()
+jsonLogDefault jlc x =
+    case jlc of
+        JsonLogDisabled -> return ()
+        JsonLogConfig v decide -> do
+            event <- toEvent <$> timedIO x
+            b     <- liftIO (decide event)
+                `catchAll` \e -> do
+                    logWarning $ sformat ("error in deciding whether to json log: "%shown) e
+                    return False
+            when b $ liftIO (withMVar v $ flip hPut $ encode event)
+                `catchAll` \e ->
+                    logWarning $ sformat ("can't write json log: "%shown) e
+
 instance ( MonadIO m
          , WithLogger m
          , Mockable Catch m) => CanJsonLog (JsonLogT m) where
 
-    jsonLog x = JsonLogT $ do
-        mv <- ask
-        case mv of
-            Nothing -> return ()
-            Just (v, decide) -> do
-                event <- toEvent <$> timedIO x
-                b     <- liftIO (decide event)
-                    `catchAll` \e -> do
-                        logWarning $ sformat ("error in deciding whether to json log: "%shown) e
-                        return False
-                when b $ liftIO (withMVar v $ flip hPut $ encode event)
-                    `catchAll` \e ->
-                        logWarning $ sformat ("can't write json log: "%shown) e
+    jsonLog x = JsonLogT (ReaderT $ \jlc -> jsonLogDefault jlc x)
 
 -- | This function simply discards all JSON log messages.
 runWithoutJsonLogT :: JsonLogT m a -> m a
-runWithoutJsonLogT (JsonLogT m) = runReaderT m Nothing
+runWithoutJsonLogT (JsonLogT m) = runReaderT m JsonLogDisabled
 
 -- | Runs a computation containing JSON log messages,
 -- either discarding all messages or writing
 -- some of them to a handle.
-runJsonLogT :: MonadIO m 
+runJsonLogT :: MonadIO m
             => Maybe (Handle, JLTimedEvent -> IO Bool) -- ^ If @'Nothing'@, JSON log messages are discarded, if @'Just' (h, f)@,
                                                        -- log messages @e@ are written to handle @h@ if @f e@ returns @True@,
                                                        -- and are otherwise discarded.
-            -> JsonLogT m a                            -- ^ A monadic computation containing JSON log messages. 
+            -> JsonLogT m a                            -- ^ A monadic computation containing JSON log messages.
             -> m a
 runJsonLogT Nothing            m            = runWithoutJsonLogT m
 runJsonLogT (Just (h, decide)) (JsonLogT m) = do
     v <- newMVar h
-    runReaderT m $ Just (v, decide)
+    runReaderT m $ JsonLogConfig v decide
 
 -- | Runs a computation containing JSON log messages,
 -- either discarding all messages or writing them to a handle.
-runJsonLogT' :: MonadIO m 
+runJsonLogT' :: MonadIO m
              => Maybe Handle -- ^ If @'Nothing'@, JSON log messages are discarded, if @'Just' h@,
                              -- log messages are written to handle @h@.
-             -> JsonLogT m a -- ^ A monadic computation containing JSON log messages. 
+             -> JsonLogT m a -- ^ A monadic computation containing JSON log messages.
              -> m a
 runJsonLogT' mh = runJsonLogT $ fmap (\h -> (h, const $ return True)) mh
 
 -- | Runs a computation containing JSON log messages,
 -- writing some of them to a handle.
-runWithJsonLogT :: MonadIO m 
-                => Handle                    -- ^ The handle to write log messages to. 
+runWithJsonLogT :: MonadIO m
+                => Handle                    -- ^ The handle to write log messages to.
                 -> (JLTimedEvent -> IO Bool) -- ^ Monadic predicate to decide whether a given log message
                                              -- should be written to the handle or be discarded.
-                -> JsonLogT m a              -- ^ A monadic computation containing JSON log messages. 
+                -> JsonLogT m a              -- ^ A monadic computation containing JSON log messages.
                 -> m a
 runWithJsonLogT h decide = runJsonLogT $ Just (h, decide)
 
 -- | Runs a computation containing JSON log messages,
 -- writing them to a handle.
-runWithJsonLogT' :: MonadIO m 
-                 => Handle       -- ^ The handle to write log messages to. 
-                 -> JsonLogT m a -- ^ A monadic computation containing JSON log messages. 
+runWithJsonLogT' :: MonadIO m
+                 => Handle       -- ^ The handle to write log messages to.
+                 -> JsonLogT m a -- ^ A monadic computation containing JSON log messages.
                  -> m a
 runWithJsonLogT' = runJsonLogT' . Just

--- a/src/Network/Broadcast/Relay/Class.hs
+++ b/src/Network/Broadcast/Relay/Class.hs
@@ -29,7 +29,7 @@ data Relay packingType m where
       , Msg.Message (ReqMsg key)
       , Msg.Message (InvOrData key contents)
       )
-      => (PropagationMsg packingType -> m ()) -- ^ How to relay the data.
+      => (PropagationMsg packingType -> m ()) -- How to relay the data.
       -> InvReqDataParams key contents m
       -> Relay packingType m
   Data ::
@@ -38,7 +38,7 @@ data Relay packingType m where
       , Msg.Serializable packingType (DataMsg contents)
       , Msg.Message (DataMsg contents)
       )
-      => (PropagationMsg packingType -> m ()) -- ^ How to relay the data.
+      => (PropagationMsg packingType -> m ()) -- How to relay the data.
       -> DataParams contents m
       -> Relay packingType m
 

--- a/src/Network/Broadcast/Relay/Types.hs
+++ b/src/Network/Broadcast/Relay/Types.hs
@@ -37,16 +37,16 @@ data PropagationMsg packingType where
         , Eq key
         , Msg.Message (ReqMsg key)
         , Msg.Serializable packingType (ReqMsg key))
-        => !(Maybe NodeId) -- ^ The peer which sent it to us.
-        -> !key            -- ^ The key (will 'InvMsg' this to peers).
-        -> !contents       -- ^ The data associated with the key.
+        => !(Maybe NodeId) -- The peer which sent it to us.
+        -> !key            -- The key (will 'InvMsg' this to peers).
+        -> !contents       -- The data associated with the key.
         -> PropagationMsg packingType
     DataOnlyPM ::
         ( Msg.Message (DataMsg contents)
         , Msg.Serializable packingType (DataMsg contents)
         , Buildable contents)
-        => !(Maybe NodeId) -- ^ The peer which sent it to us.
-        -> !contents       -- ^ The data.
+        => !(Maybe NodeId) -- The peer which sent it to us.
+        -> !contents       -- The data.
         -> PropagationMsg packingType
 
 instance Buildable (PropagationMsg packingType) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
 resolver: lts-8.5
 
+flags:
+  ether:
+    disable-tup-instances: true
+
 packages:
   - '.'
   - location:


### PR DESCRIPTION
In https://github.com/input-output-hk/cardano-sl/pull/967/ I removed as many transformer layers as possible, `JsonLogT` being one of them. Instead, I need to put this `JsonLogConfig` into a `ReaderT` at the bottom of the transformer stack, and then use `jsonLogDefault` to implement the `CanJsonLog` instance.

This patch does not change the semantics of the module and merely exports `JsonLogConfig` and `jsonLogDefault`.

(Ah, and I also fixed Haddock build)