### PR TITLE
Redesign of packing type to support CBOR decoding

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -27,7 +27,7 @@ import           Node                       (Listener (..), NodeAction (..), nod
                                              simpleNodeEndPoint, noReceiveDelay, NodeId)
 import           Node.Conversation
 import           Node.OutboundQueue
-import           Node.Message.Binary        (BinaryP (..))
+import           Node.Message.Binary        (BinaryP, binaryPacking)
 import           ReceiverOptions            (Args (..), argsParser)
 
 main :: IO ()
@@ -55,7 +55,7 @@ main = do
         mkOutboundQueue converse = pure (freeForAll id converse)
 
     runProduction $ usingLoggerName "receiver" $ do
-        node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prng BinaryP () defaultNodeEnvironment $ \_ ->
+        node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prng binaryPacking () defaultNodeEnvironment $ \_ ->
             NodeAction (const [pingListener noPong]) $ \_ -> do
                 threadDelay (fromIntegral duration :: Second)
   where

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -34,7 +34,7 @@ import           Node                           (NodeAction (..), node, Node(Nod
                                                  defaultNodeEnvironment, simpleNodeEndPoint,
                                                  noReceiveDelay)
 import           Node.Internal                  (NodeId (..))
-import           Node.Message.Binary            (BinaryP (..))
+import           Node.Message.Binary            (BinaryP, binaryPacking)
 import           Node.Conversation
 import           Node.OutboundQueue
 
@@ -89,7 +89,7 @@ main = do
             let pingWorkers = liftA2 (pingSender prngWork payloadBound startTime msgRate)
                                      tasksIds
                                      (zip [0, msgNum..] nodeIds)
-            node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prngNode BinaryP () defaultNodeEnvironment $ \node' ->
+            node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prngNode binaryPacking () defaultNodeEnvironment $ \node' ->
                 NodeAction (const []) $ \sactions -> do
                     drones <- forM nodeIds (startDrone node')
                     _ <- forM pingWorkers (fork . flip ($) sactions)

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -31,7 +31,7 @@ import qualified Network.Transport.TCP                as TCP
 import           Node
 import           Node.Conversation
 import           Node.OutboundQueue
-import           Node.Message.Binary                  (BinaryP (..))
+import           Node.Message.Binary                  (BinaryP, binaryPacking)
 import           System.Environment                   (getArgs)
 import           System.Random
 
@@ -102,7 +102,7 @@ makeNode transport i = do
             -> Production (OutboundQueue BinaryP B8.ByteString NodeId () Production)
         mkOutboundQueue converse = pure (freeForAll id converse)
     fork $ node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
-                mkOutboundQueue prng1 BinaryP (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
+                mkOutboundQueue prng1 binaryPacking (B8.pack "my peer data!") defaultNodeEnvironment $ \node' ->
         NodeAction (listeners . nodeId $ node') $ \sactions -> do
             liftIO . putStrLn $ "Making discovery for node " ++ show i
             discovery <- K.kademliaDiscovery kademliaConfig initialPeer (nodeEndPointAddress node')

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -29,7 +29,7 @@ import qualified Network.Transport.TCP      as TCP
 import           Node
 import           Node.Conversation
 import           Node.OutboundQueue
-import           Node.Message.Store         (StoreP (..))
+import           Node.Message.Store         (StoreP, storePacking)
 import           Node.Util.Monitor          (startMonitor)
 import           System.Random
 
@@ -100,11 +100,11 @@ main = runProduction $ do
             -> Production (OutboundQueue Packing B8.ByteString NodeId () Production)
         mkOutboundQueue converse = pure (freeForAll id converse)
     node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
-         mkOutboundQueue prng1 StoreP (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
+         mkOutboundQueue prng1 storePacking (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \sactions1 -> do
             _ <- startMonitor 8000 runProduction node1
             node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
-                  mkOutboundQueue prng2 StoreP (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
+                  mkOutboundQueue prng2 storePacking (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \sactions2 -> do
                     _ <- startMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] sactions1

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -487,7 +487,7 @@ recvNext packing limit (LL.ChannelIn channel) = do
             unless (BS.null trailing) (Channel.unGetChannel channel (Just trailing))
             return outcome
   where
-    go remaining decoderStep = case decoderStep of
+    go !remaining decoderStep = case decoderStep of
         -- TODO use the error message in the exception.
         Fail _ _ _ -> throw NoParse
         Done trailing _ thing -> return (trailing, Input thing)
@@ -497,5 +497,5 @@ recvNext packing limit (LL.ChannelIn channel) = do
             case mbs of
                 Nothing -> runDecoder (next Nothing) >>= go remaining
                 Just bs ->
-                    let !remaining' = remaining - BS.length bs
+                    let remaining' = remaining - BS.length bs
                     in  runDecoder (next (Just bs)) >>= go remaining'

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -481,7 +481,7 @@ recvNext packing limit (LL.ChannelIn channel) = do
             -- some limited number of bytes, so 'go' may bring in at most this
             -- many more than the limit.
             let limit' = limit - BS.length bs
-            (trailing, outcome) <- go limit' (continueDecoding (unpackMsg packing) [bs])
+            (trailing, outcome) <- go limit' (continueDecoding (unpackMsg packing) bs)
             unless (BS.null trailing) (Channel.unGetChannel channel (Just trailing))
             return outcome
   where

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -493,7 +493,7 @@ recvNext packing limit (LL.ChannelIn channel) = do
             when (remaining <= 0) (throw LimitExceeded)
             mbs <- Channel.readChannel channel
             case mbs of
-                Nothing -> return (BS.empty, End)
+                Nothing -> go remaining (next Nothing)
                 Just bs ->
                     let !remaining' = remaining - BS.length bs
                     in  go remaining' (next (Just bs))

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -972,7 +972,7 @@ nodeDispatcher node handlerInOut =
                 Nothing -> do
                     let decoder :: Decoder peerData
                         decoder = unpackMsg (nodePackingType node)
-                    case continueDecoding decoder chunks of
+                    case continueDecoding decoder (BS.concat chunks) of
                         Fail _ _ err -> do
                             logWarning $ sformat ("failed to decode peer data from " % shown % ": got error " % shown) peer err
                             return $ state {

--- a/src/Node/Message/Binary.hs
+++ b/src/Node/Message/Binary.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Node.Message.Binary
-    ( BinaryP (..)
+    ( BinaryP
+    , binaryP
+    , binaryPacking
     , binaryPackMsg
     , binaryUnpackMsg
     ) where
@@ -13,11 +16,28 @@ import qualified Data.Binary.Put               as Bin
 import qualified Data.Binary.Get               as Bin
 import qualified Data.ByteString.Builder.Extra as BS
 import qualified Data.ByteString.Lazy          as LBS
+import           Data.Functor.Identity         (Identity (..))
+import           Data.Proxy                    (Proxy (..))
 import qualified Data.Text                     as T
-import           Node.Message.Decoder          (Decoder (..))
-import           Node.Message.Class            (Serializable (..))
+import           Node.Message.Class            (Serializable (..), PackingType (..), Packing (..))
+import           Node.Message.Decoder          (Decoder (..), DecoderStep (..))
 
-data BinaryP = BinaryP
+data BinaryP
+
+binaryP :: Proxy BinaryP
+binaryP = Proxy
+
+-- | BinaryP packing works in any Applicative.
+binaryPacking :: ( Applicative m ) => Packing BinaryP m
+binaryPacking = Packing
+    { packingType = binaryP
+    , packM = pure . runIdentity
+    , unpackM = pure . runIdentity
+    }
+
+instance PackingType BinaryP where
+    type PackM BinaryP = Identity
+    type UnpackM BinaryP = Identity
 
 binaryPackMsg :: Bin.Put -> LBS.ByteString
 binaryPackMsg =
@@ -26,20 +46,14 @@ binaryPackMsg =
         LBS.empty
     . Bin.execPut
 
-binaryUnpackMsg :: Bin.Get t -> Decoder t
-binaryUnpackMsg get = fromBinaryDecoder (Bin.runGetIncremental get)
+binaryUnpackMsg :: Bin.Get t -> Decoder (UnpackM BinaryP) t
+binaryUnpackMsg get = Decoder (pure (fromBinaryDecoder (Bin.runGetIncremental get)))
 
-fromBinaryDecoder :: Bin.Decoder t -> Decoder t
+fromBinaryDecoder :: Bin.Decoder t -> DecoderStep (UnpackM BinaryP) t
 fromBinaryDecoder (Bin.Done bs bo t) = Done bs bo t
 fromBinaryDecoder (Bin.Fail bs bo err) = Fail bs bo (T.pack err)
-fromBinaryDecoder (Bin.Partial k) = Partial (fromBinaryDecoder . k)
+fromBinaryDecoder (Bin.Partial k) = Partial (Decoder . pure . fromBinaryDecoder . k)
 
--- TBD some way to make custom serialization strategies.
--- Perhaps a new typeclass
---
---   Bin.Binary t => BinarySerializable t
---
--- with default binary packing/unpacking functions.
-instance Bin.Binary t => Serializable BinaryP t where
-    packMsg _ = binaryPackMsg . Bin.put
+instance ( Bin.Binary t ) => Serializable BinaryP t where
+    packMsg _ = pure . binaryPackMsg . Bin.put
     unpackMsg _ = binaryUnpackMsg Bin.get

--- a/src/Node/Message/Class.hs
+++ b/src/Node/Message/Class.hs
@@ -10,7 +10,13 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 module Node.Message.Class
-    ( Serializable (..)
+    ( PackingType (..)
+    , Serializable (..)
+
+    , Packing (..)
+
+    , pack
+    , unpack
 
     , Message (..)
     , messageName'
@@ -32,7 +38,7 @@ import qualified Data.Text.Buildable           as B
 import qualified Formatting                    as F
 import           GHC.Generics                  (Generic)
 import           Serokell.Util.Base16          (base16F)
-import           Node.Message.Decoder          (Decoder)
+import           Node.Message.Decoder          (Decoder, hoistDecoder)
 
 -- * Message name
 
@@ -71,11 +77,30 @@ messageName' = messageName . proxyOf
     proxyOf :: a -> Proxy a
     proxyOf _ = Proxy
 
+class PackingType packingType where
+    type PackM packingType :: * -> *
+    type UnpackM packingType :: * -> *
+
 -- | Defines a way to serialize object @r@ with given packing type @p@.
+-- The @PackM@, @UnpackM@ monadic contexts of the given packing type are used.
 --
 -- TODO should use a proxy on packing rather than a value, no?
-class Serializable packing thing where
+class ( PackingType packingType ) => Serializable packingType thing where
     -- | Way of packing data to raw bytes.
-    packMsg :: packing -> thing -> LBS.ByteString
+    packMsg :: Proxy packingType -> thing -> PackM packingType LBS.ByteString
     -- | Incrementally unpack.
-    unpackMsg :: packing -> Decoder thing
+    unpackMsg :: Proxy packingType -> Decoder (UnpackM packingType) thing
+
+-- | Picks out a packing type and injections to make it useful within a given
+-- monad.
+data Packing packingType m = Packing
+    { packingType :: Proxy packingType
+    , packM :: forall t . PackM packingType t -> m t
+    , unpackM :: forall t . UnpackM packingType t -> m t
+    }
+
+pack :: ( Functor m, Serializable packingType t ) => Packing packingType m -> t -> m LBS.ByteString
+pack Packing {..} = packM . packMsg packingType
+
+unpack :: ( Functor m, Serializable packingType t ) => Packing packingType m -> Decoder m t
+unpack Packing {..} = hoistDecoder unpackM (unpackMsg packingType)

--- a/src/Node/Message/Decoder.hs
+++ b/src/Node/Message/Decoder.hs
@@ -17,9 +17,9 @@ data Decoder t =
 
 continueDecoding
     :: Decoder t
-    -> [BS.ByteString]
+    -> BS.ByteString
     -> Decoder t
-continueDecoding decoder bss = case decoder of
-    Done trailing offset t -> Done (BS.concat $ trailing : bss) offset t
-    Fail trailing offset err -> Fail (BS.concat $ trailing : bss) offset err
-    Partial k -> k $ Just (BS.concat bss)
+continueDecoding decoder bs = case decoder of
+    Done trailing offset t -> Done (BS.append trailing bs) offset t
+    Fail trailing offset err -> Fail (BS.append trailing bs) offset err
+    Partial k -> k $ Just bs

--- a/src/Node/Message/Decoder.hs
+++ b/src/Node/Message/Decoder.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Node.Message.Decoder
     ( Decoder (..)
+    , DecoderStep (..)
     , ByteOffset
     , continueDecoding
+    , hoistDecoder
+    , hoistDecoderStep
     ) where
 
 import           Data.Int         (Int64)
@@ -10,16 +15,40 @@ import qualified Data.Text        as T
 
 type ByteOffset = Int64
 
-data Decoder t =
+data DecoderStep m t =
       Done !BS.ByteString !ByteOffset !t
     | Fail !BS.ByteString !ByteOffset !T.Text
-    | Partial (Maybe BS.ByteString -> Decoder t)
+    | Partial (Maybe BS.ByteString -> Decoder m t)
 
+newtype Decoder m t = Decoder {
+      runDecoder :: m (DecoderStep m t)
+    }
+
+hoistDecoder
+    :: ( Functor n )
+    => (forall a . m a -> n a)
+    -> Decoder m t
+    -> Decoder n t
+hoistDecoder nat (Decoder m) = Decoder (hoistDecoderStep nat <$> nat m)
+
+hoistDecoderStep
+    :: ( Functor n )
+    => (forall a . m a -> n a)
+    -> DecoderStep m t
+    -> DecoderStep n t
+hoistDecoderStep nat step = case step of
+    Done trailing offset t -> Done trailing offset t
+    Fail trailing offset err -> Fail trailing offset err
+    Partial k -> Partial $ hoistDecoder nat . k
+
+-- | Feed input through a decoder.
+--
 continueDecoding
-    :: Decoder t
+    :: ( Monad m )
+    => DecoderStep m t
     -> BS.ByteString
-    -> Decoder t
-continueDecoding decoder bs = case decoder of
-    Done trailing offset t -> Done (BS.append trailing bs) offset t
-    Fail trailing offset err -> Fail (BS.append trailing bs) offset err
-    Partial k -> k $ Just bs
+    -> m (DecoderStep m t)
+continueDecoding decoderStep bs = case decoderStep of
+    Done trailing offset t -> pure $ Done (BS.append trailing bs) offset t
+    Fail trailing offset err -> pure $ Fail (BS.append trailing bs) offset err
+    Partial k -> runDecoder (k (Just bs))

--- a/src/Node/Message/Store.hs
+++ b/src/Node/Message/Store.hs
@@ -3,27 +3,47 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Node.Message.Store
-    ( StoreP (..)
+    ( StoreP
+    , storeP
+    , storePacking
     , storeDecoder
     ) where
 
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as LBS
+import           Data.Functor.Identity      (Identity (..))
+import           Data.Proxy                 (Proxy (..))
 import qualified Data.Store                 as Store
 import           Data.Word                  (Word32)
 import qualified Network.Transport.Internal as NT (decodeWord32, encodeWord32)
-import           Node.Message.Class         (Serializable (..))
-import           Node.Message.Decoder       (Decoder (..))
+import           Node.Message.Class         (Serializable (..), PackingType (..), Packing (..))
+import           Node.Message.Decoder       (Decoder (..), DecoderStep (..))
 
-data StoreP = StoreP
+data StoreP
+
+instance PackingType StoreP where
+    type PackM StoreP = Identity
+    type UnpackM StoreP = Identity
+
+storeP :: Proxy StoreP
+storeP = Proxy
+
+-- | StoreP packing works in any Applicative.
+storePacking :: ( Applicative m ) => Packing StoreP m
+storePacking = Packing
+    { packingType = storeP
+    , packM = pure . runIdentity
+    , unpackM = pure . runIdentity
+    }
 
 instance Store.Store t => Serializable StoreP t where
 
     -- Length-prefix the store-encoded body. The length is assumed to fit into
     -- 32 bits.
-    packMsg _ t = encoded
+    packMsg _ t = pure encoded
       where
         encodedBody = Store.encode t
         encodedLength = NT.encodeWord32 (fromIntegral (BS.length encodedBody))
@@ -31,13 +51,13 @@ instance Store.Store t => Serializable StoreP t where
 
     unpackMsg _ = storeDecoder Store.peek BS.empty
 
-storeDecoder :: Store.Peek t -> BS.ByteString  -> Decoder t
-storeDecoder peek bs = Partial $ \mbs -> case mbs of
-    Nothing -> Fail BS.empty (fromIntegral (BS.length bs)) "Unexpected end of input (length prefix)"
+storeDecoder :: Store.Peek t -> BS.ByteString  -> Decoder (UnpackM StoreP) t
+storeDecoder peek bs = Decoder . pure . Partial $ \mbs -> case mbs of
+    Nothing -> Decoder . pure $ Fail BS.empty (fromIntegral (BS.length bs)) "Unexpected end of input (length prefix)"
     Just bs' ->
         let (front, back) = BS.splitAt 4 (BS.append bs bs')
         in  if BS.length front == 4
-            then storeDecoderBody peek (NT.decodeWord32 front) [] (Just back)
+            then Decoder . pure $ storeDecoderBody peek (NT.decodeWord32 front) [] (Just back)
             -- In this case, back is empty and front has length strictly less
             -- than 4, so we have to wait for more input.
             else storeDecoder peek front
@@ -47,7 +67,7 @@ storeDecoderBody
     -> Word32
     -> [BS.ByteString]
     -> Maybe BS.ByteString
-    -> Decoder t
+    -> DecoderStep (UnpackM StoreP) t
 storeDecoderBody peek !remaining !acc !mbs = case mbs of
     Nothing -> Fail BS.empty (fromIntegral (BS.length (accumulate acc))) "Unexpected end of input (body)"
     Just bs ->
@@ -56,7 +76,7 @@ storeDecoderBody peek !remaining !acc !mbs = case mbs of
             acc' = front : acc
             remaining' = remaining - taken
         in  if taken < remaining
-            then Partial $ storeDecoderBody peek remaining' acc'
+            then Partial $ Decoder . pure . storeDecoderBody peek remaining' acc'
             else let body = accumulate acc' in case Store.decodeWith peek body of
                 Left ex -> Fail back (fromIntegral (BS.length body)) (Store.peekExMessage ex)
                 Right t -> Done back (fromIntegral (BS.length body)) t

--- a/test/Test/NodeSpec.hs
+++ b/test/Test/NodeSpec.hs
@@ -45,7 +45,7 @@ import           Mockable.SharedExclusive    (newSharedExclusive, readSharedExcl
 import           Mockable.Concurrent         (withAsync, wait, Async, Delay, delay)
 import           Mockable.Exception          (catch, throw)
 import           Mockable.Production         (Production, runProduction)
-import           Node.Message.Binary         (BinaryP(..))
+import           Node.Message.Binary         (BinaryP, binaryPacking)
 import           Node
 import           Node.Conversation
 import           Node.OutboundQueue
@@ -99,13 +99,13 @@ spec = describe "Node" $ modifyMaxSuccess (const 50) $ do
                                 _ <- timeout "server sending response" 30000000 (send cactions (Parcel i (Payload 32)))
                                 return ()
 
-                let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue serverGen BinaryP ("server" :: String, 42 :: Int) nodeEnv $ \_node ->
+                let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue serverGen binaryPacking ("server" :: String, 42 :: Int) nodeEnv $ \_node ->
                         NodeAction (const [listener]) $ \sendActions -> do
                             putSharedExclusive serverAddressVar (nodeId _node)
                             takeSharedExclusive clientFinished
                             putSharedExclusive serverFinished ()
 
-                let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue clientGen BinaryP ("client" :: String, 24 :: Int) nodeEnv $ \_node ->
+                let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue clientGen binaryPacking ("client" :: String, 24 :: Int) nodeEnv $ \_node ->
                         NodeAction (const [listener]) $ \sendActions -> do
                             serverAddress <- readSharedExclusive serverAddressVar
                             forM_ [1..attempts] $ \i -> withConnectionTo sendActions serverAddress $ \peerData -> Conversation $ \cactions -> do
@@ -144,7 +144,7 @@ spec = describe "Node" $ modifyMaxSuccess (const 50) $ do
                                 _ <- send cactions (Parcel i (Payload 32))
                                 return ()
 
-                node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue gen BinaryP ("some string" :: String, 42 :: Int) nodeEnv $ \_node ->
+                node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue gen binaryPacking ("some string" :: String, 42 :: Int) nodeEnv $ \_node ->
                     NodeAction (const [listener]) $ \sendActions -> do
                         forM_ [1..attempts] $ \i -> withConnectionTo sendActions (nodeId _node) $ \peerData -> Conversation $ \cactions -> do
                             True <- return $ peerData == ("some string", 42)
@@ -178,7 +178,7 @@ spec = describe "Node" $ modifyMaxSuccess (const 50) $ do
                         handleThreadKilled Timeout = do
                             --liftIO . putStrLn $ "Thread killed successfully!"
                             return ()
-                    node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue gen BinaryP () env $ \_node ->
+                    node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue gen binaryPacking () env $ \_node ->
                         NodeAction (const []) $ \sendActions -> do
                             timeout "client waiting for ACK" 5000000 $
                                 flip catch handleThreadKilled $ withConnectionTo sendActions peerAddr $ \peerData -> Conversation $ \cactions -> do

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -84,7 +84,7 @@ import           Node                        (ConversationActions (..),
                                               enqueueConversation')
 import           Node.Conversation           (Converse)
 import           Node.OutboundQueue          (freeForAll, OutboundQueue)
-import           Node.Message.Binary         (BinaryP (..))
+import           Node.Message.Binary         (BinaryP, binaryPacking)
 
 -- | Run a computation, but kill it if it takes more than a given number of
 --   Microseconds to complete. If that happens, log using a given string
@@ -318,7 +318,7 @@ deliveryTest transport_ nodeEnv testState workers listeners = runProduction $ do
             -> Production (OutboundQueue BinaryP () NodeId () Production)
         mkOutboundQueue converse = pure (freeForAll id converse)
 
-    let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prng1 BinaryP () nodeEnv $ \serverNode -> do
+    let server = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prng1 binaryPacking () nodeEnv $ \serverNode -> do
             NodeAction (const listeners) $ \_ -> do
                 -- Give our address to the client.
                 putSharedExclusive serverAddressVar (nodeId serverNode)
@@ -329,7 +329,7 @@ deliveryTest transport_ nodeEnv testState workers listeners = runProduction $ do
                 -- Allow the client to stop.
                 putSharedExclusive serverFinished ()
 
-    let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prng2 BinaryP () nodeEnv $ \clientNode ->
+    let client = node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) mkOutboundQueue prng2 binaryPacking () nodeEnv $ \clientNode ->
             NodeAction (const []) $ \sendActions -> do
                 serverAddress <- takeSharedExclusive serverAddressVar
                 let act = void . forConcurrently workers $ \worker ->


### PR DESCRIPTION
- The `Decoder` type is parameterzsed by some `* -> *` type.
- A packing type need not (shouldn't) be inhabited, but must be an instance of the new `PackingType` class which determines concrete monadic context for encoding and decoding. For existing store and binary packing types these are all `Identity`.
- To use a packing type instance `packingType` to run a node over `m`, a `Packing packingType m` must be given. See `unpack` and `pack` in `Node.Message.Class`.
- Fix `recvNext` in case end of input happens during a partial parse. Previously it would `End` but now it correctly throws `NoParse`.
- `continueDecoding` now takes a single `ByteString` rather than `[ByteString]`.