### PR TITLE
[CSL-849] messageCode :: Word16 to identify conv

### DIFF
--- a/bench/Receiver/Main.hs
+++ b/bench/Receiver/Main.hs
@@ -14,7 +14,7 @@ import           GHC.IO.Encoding            (setLocaleEncoding, utf8)
 import           Options.Applicative.Simple (simpleOptions)
 import           Serokell.Util.Concurrent   (threadDelay)
 import           System.Random              (mkStdGen)
-import           System.Wlog                (LoggerNameBox, usingLoggerName)
+import           System.Wlog                (usingLoggerName)
 
 import           Mockable                   (Production (runProduction))
 
@@ -24,8 +24,8 @@ import qualified Network.Transport.TCP      as TCP
 import           Network.Transport.Concrete (concrete)
 import           Node                       (Listener (..), NodeAction (..), node,
                                              defaultNodeEnvironment, ConversationActions (..),
-                                             simpleNodeEndPoint, noReceiveDelay, NodeId)
-import           Node.Message.Binary        (BinaryP, binaryPacking)
+                                             simpleNodeEndPoint, noReceiveDelay)
+import           Node.Message.Binary        (binaryPacking)
 import           ReceiverOptions            (Args (..), argsParser)
 
 main :: IO ()

--- a/bench/Sender/Main.hs
+++ b/bench/Sender/Main.hs
@@ -33,7 +33,7 @@ import           Node                           (NodeAction (..), node, Node(Nod
                                                  defaultNodeEnvironment, simpleNodeEndPoint,
                                                  noReceiveDelay, converseWith)
 import           Node.Internal                  (NodeId (..))
-import           Node.Message.Binary            (BinaryP, binaryPacking)
+import           Node.Message.Binary            (binaryPacking)
 
 
 import           Bench.Network.Commons          (MeasureEvent (..), Payload (..),

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -41,6 +41,7 @@ instance Binary Pong where
 type Packing = BinaryP
 
 instance Message Void where
+    messageCode _ = 0
     formatMessage = absurd
 
 worker

--- a/examples/Discovery.hs
+++ b/examples/Discovery.hs
@@ -33,7 +33,7 @@ import           Node.Message.Binary                  (BinaryP, binaryPacking)
 import           System.Environment                   (getArgs)
 import           System.Random
 
-data Pong = Pong
+data Pong = Pong BS.ByteString
 deriving instance Generic Pong
 deriving instance Show Pong
 instance Binary Pong where
@@ -70,7 +70,7 @@ worker anId generator discovery = pingWorker generator
                 \_peerData -> Conversation $ \(cactions :: ConversationActions Void Pong Production) -> do
                     received <- recv cactions maxBound
                     case received of
-                        Just Pong -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show addr
+                        Just (Pong _) -> liftIO . putStrLn $ show anId ++ " heard PONG from " ++ show addr
                         Nothing -> error "Unexpected end of input"
             loop gen'
 
@@ -83,7 +83,7 @@ listeners anId peerData = [pongListener]
     pongListener :: Listener Packing BS.ByteString Production
     pongListener = Listener $ \_ peerId (cactions :: ConversationActions Pong Void Production) -> do
         liftIO . putStrLn $ show anId ++  " heard PING from " ++ show peerId ++ " with peer data " ++ B8.unpack peerData
-        send cactions Pong
+        send cactions (Pong "")
 
 makeNode :: Transport Production
          -> Int

--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -37,6 +37,7 @@ deriving instance Data Ping
 deriving instance Show Ping
 instance Binary Ping
 instance Message Ping where
+    messageCode _ = 0
     formatMessage _ = "Ping"
 
 -- | Type for messages from the listeners to the workers.

--- a/src/Bench/Network/Commons.hs
+++ b/src/Bench/Network/Commons.hs
@@ -61,12 +61,14 @@ data Ping = Ping MsgId Payload
     deriving (Generic, Data, Binary)
 
 instance Message Ping where
+    messageCode _ = 0
     formatMessage _ = "Ping"
 
 data Pong = Pong MsgId Payload
     deriving (Generic, Data, Binary)
 
 instance Message Pong where
+    messageCode _ = 1
     formatMessage _ = "Pong"
 
 instance Binary Payload where

--- a/src/Node/Message/Class.hs
+++ b/src/Node/Message/Class.hs
@@ -19,49 +19,26 @@ module Node.Message.Class
     , unpack
 
     , Message (..)
-    , messageName'
+    , messageCode'
 
-    , MessageName (..)
+    , MessageCode
     ) where
 
-import qualified Data.Binary                   as Bin
-import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Lazy          as LBS
-import           Data.Data                     (Data, dataTypeName, dataTypeOf)
-import           Data.Hashable                 (Hashable)
-import           Data.Proxy                    (Proxy (..), asProxyTypeOf)
-import           Data.String                   (IsString, fromString)
+import           Data.Proxy                    (Proxy (..))
 import qualified Data.Text                     as T
-import           Data.Text.Buildable           (Buildable)
-import qualified Data.Text.Buildable           as B
+import           Data.Word                     (Word16)
 import qualified Formatting                    as F
-import           GHC.Generics                  (Generic)
-import           Serokell.Util.Base16          (base16F)
 import           Node.Message.Decoder          (Decoder, hoistDecoder)
 
 -- * Message name
 
-newtype MessageName = MessageName BS.ByteString
-deriving instance Eq MessageName
-deriving instance Ord MessageName
-deriving instance Show MessageName
-deriving instance Generic MessageName
-deriving instance IsString MessageName
-deriving instance Hashable MessageName
-deriving instance Monoid MessageName
-instance Bin.Binary MessageName
+type MessageCode = Word16
 
-instance Buildable MessageName where
-    build (MessageName mn) = F.bprint base16F mn
-
--- | Defines type with it's own `MessageName`.
+-- | Defines type with it's own `MessageCode`.
 class Message m where
     -- | Uniquely identifies this type
-    messageName :: Proxy m -> MessageName
-    default messageName :: Data m => Proxy m -> MessageName
-    messageName proxy =
-         MessageName . fromString . dataTypeName . dataTypeOf $
-            undefined `asProxyTypeOf` proxy
+    messageCode :: Proxy m -> MessageCode
 
     -- | Description of message, for debug purposes
     formatMessage :: m -> T.Text
@@ -69,8 +46,8 @@ class Message m where
     formatMessage = F.sformat F.build
 
 -- | As `messageName`, but accepts message itself, may be more convinient is most cases.
-messageName' :: Message m => m -> MessageName
-messageName' = messageName . proxyOf
+messageCode' :: Message m => m -> MessageCode
+messageCode' = messageCode . proxyOf
   where
     proxyOf :: a -> Proxy a
     proxyOf _ = Proxy

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -129,7 +129,7 @@ data Parcel = Parcel
 
 instance Binary Parcel
 instance Message Parcel where
-    messageName _ = "Parcel"
+    messageCode _ = 0
     formatMessage _ = "Parcel"
 
 instance Arbitrary Parcel where


### PR DESCRIPTION
This is the simplest way to satisfy CSL-849, but I'm tempted to do more.

The message code / name should not be determined by the send type of the
conversation. Really what we want to express is a code for a listener.