### PR TITLE
Bring policies in line with latest spec / bugfixes

### DIFF
--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -140,7 +140,7 @@ enumPrecHighestFirst = reverse enumPrecLowestFirst
 --
 -- If we cannot find any alternative that doesn't match requirements we simply
 -- give up on forwarding set.
-data MaxAhead = MaxAhead Int
+newtype MaxAhead = MaxAhead Int
   deriving Show
 
 -- | Enqueueing instruction

--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -140,7 +140,7 @@ enumPrecHighestFirst = reverse enumPrecLowestFirst
 --
 -- If we cannot find any alternative that doesn't match requirements we simply
 -- give up on forwarding set.
-data MaxAhead = MaxAhead Int | UnlimitedMaxAhead
+data MaxAhead = MaxAhead Int
   deriving Show
 
 -- | Enqueueing instruction
@@ -198,7 +198,7 @@ defaultEnqueuePolicyCore = go
       ]
     go (MsgRequestBlocks _) = [
         -- We never ask for data from edge nodes
-        EnqueueOne [NodeRelay, NodeCore] UnlimitedMaxAhead PHigh
+        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 1) PHigh
       ]
     go (MsgMPC _) = [
         EnqueueAll NodeCore (MaxAhead 1) PMedium
@@ -257,7 +257,7 @@ defaultEnqueuePolicyEdgeBehindNat = go
       ]
     go (MsgRequestBlocks _) = [
         -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
+        EnqueueOne [NodeRelay] (MaxAhead 0) PHigh
       ]
     go (MsgMPC _) = [
         -- not relevant
@@ -283,7 +283,7 @@ defaultEnqueuePolicyEdgeExchange = go
       ]
     go (MsgRequestBlocks _) = [
         -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
+        EnqueueOne [NodeRelay] (MaxAhead 0) PHigh
       ]
     go (MsgMPC _) = [
         -- not relevant

--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -353,7 +353,7 @@ defaultDequeuePolicyCore = go
   where
     go :: DequeuePolicy
     go NodeCore  = Dequeue NoRateLimiting (MaxInFlight 3)
-    go NodeRelay = Dequeue NoRateLimiting (MaxInFlight 1)
+    go NodeRelay = Dequeue NoRateLimiting (MaxInFlight 2)
     go NodeEdge  = error "defaultDequeuePolicy: core to edge not applicable"
 
 -- | Dequeueing policy for relay nodes
@@ -361,9 +361,9 @@ defaultDequeuePolicyRelay :: DequeuePolicy
 defaultDequeuePolicyRelay = go
   where
     go :: DequeuePolicy
-    go NodeCore  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 1)
+    go NodeCore  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
     go NodeRelay = Dequeue (MaxMsgPerSec 3) (MaxInFlight 2)
-    go NodeEdge  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 1)
+    go NodeEdge  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
 
 -- | Dequeueing policy for standard behind-NAT edge nodes
 defaultDequeuePolicyEdgeBehindNat :: DequeuePolicy
@@ -371,7 +371,7 @@ defaultDequeuePolicyEdgeBehindNat = go
   where
     go :: DequeuePolicy
     go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
-    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 1)
+    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
     go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
 
 -- | Dequeueing policy for exchange edge nodes
@@ -389,7 +389,7 @@ defaultDequeuePolicyEdgeP2P = go
   where
     go :: DequeuePolicy
     go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
-    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 1)
+    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
     go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
 
 {-------------------------------------------------------------------------------

--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -183,7 +183,7 @@ defaultEnqueuePolicy NodeCore  = defaultEnqueuePolicyCore
 defaultEnqueuePolicy NodeRelay = defaultEnqueuePolicyRelay
 defaultEnqueuePolicy NodeEdge  = defaultEnqueuePolicyEdgeBehindNat
 
--- | Default enqueue policy for code nodes
+-- | Default enqueue policy for core nodes
 defaultEnqueuePolicyCore :: EnqueuePolicy nid
 defaultEnqueuePolicyCore = go
   where
@@ -196,7 +196,7 @@ defaultEnqueuePolicyCore = go
         EnqueueAll NodeCore  (MaxAhead 1) PHigh
       , EnqueueAll NodeRelay (MaxAhead 1) PHigh
       ]
-    go (MsgRequestBlock _) = [
+    go (MsgRequestBlocks _) = [
         -- We never ask for data from edge nodes
         EnqueueOne [NodeRelay, NodeCore] UnlimitedMaxAhead PHigh
       ]
@@ -224,9 +224,9 @@ defaultEnqueuePolicyRelay = go
         EnqueueAll NodeCore  (MaxAhead 1) PHigh
       , EnqueueAll NodeRelay (MaxAhead 1) PHigh
       ]
-    go (MsgRequestBlock _) = [
-        -- We never ask for data from edge nodes
-        EnqueueOne [NodeRelay, NodeCore] UnlimitedMaxAhead PHigh
+    go (MsgRequestBlocks _) = [
+        -- We never ask for blocks from edge nodes
+        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 1) PHigh
       ]
     go (MsgTransaction _) = [
         EnqueueAll NodeCore  (MaxAhead 20) PLow
@@ -244,7 +244,7 @@ defaultEnqueuePolicyEdgeBehindNat = go
     -- Enqueue policy for edge nodes
     go :: EnqueuePolicy nid
     go (MsgTransaction OriginSender) = [
-        EnqueueAll NodeRelay (MaxAhead 0) PLow
+        EnqueueAll NodeRelay (MaxAhead 1) PLow
       ]
     go (MsgTransaction (OriginForward _)) = [
         -- don't forward transactions that weren't created at this node
@@ -253,9 +253,9 @@ defaultEnqueuePolicyEdgeBehindNat = go
         -- not forwarded
       ]
     go MsgRequestBlockHeaders = [
-        EnqueueAll NodeRelay (MaxAhead 1) PHigh
+        EnqueueAll NodeRelay (MaxAhead 0) PHigh
       ]
-    go (MsgRequestBlock _) = [
+    go (MsgRequestBlocks _) = [
         -- Edge nodes can only talk to relay nodes
         EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
       ]
@@ -279,9 +279,9 @@ defaultEnqueuePolicyEdgeExchange = go
         -- not forwarded
       ]
     go MsgRequestBlockHeaders = [
-        EnqueueAll NodeRelay (MaxAhead 1) PHigh
+        EnqueueAll NodeRelay (MaxAhead 0) PHigh
       ]
-    go (MsgRequestBlock _) = [
+    go (MsgRequestBlocks _) = [
         -- Edge nodes can only talk to relay nodes
         EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
       ]
@@ -295,11 +295,8 @@ defaultEnqueuePolicyEdgeP2P = go
   where
     -- Enqueue policy for edge nodes
     go :: EnqueuePolicy nid
-    go (MsgTransaction OriginSender) = [
+    go (MsgTransaction _) = [
         EnqueueAll NodeRelay (MaxAhead 3) PLow
-      ]
-    go (MsgTransaction (OriginForward _)) = [
-        -- don't forward transactions that weren't created at this node
       ]
     go (MsgAnnounceBlockHeader _) = [
         EnqueueAll NodeRelay (MaxAhead 0) PHighest
@@ -307,9 +304,9 @@ defaultEnqueuePolicyEdgeP2P = go
     go MsgRequestBlockHeaders = [
         EnqueueAll NodeRelay (MaxAhead 1) PHigh
       ]
-    go (MsgRequestBlock _) = [
+    go (MsgRequestBlocks _) = [
         -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
+        EnqueueOne [NodeRelay] (MaxAhead 1) PHigh
       ]
     go (MsgMPC _) = [
         -- not relevant

--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -253,11 +253,11 @@ defaultEnqueuePolicyEdgeBehindNat = go
         -- not forwarded
       ]
     go MsgRequestBlockHeaders = [
-        EnqueueAll NodeRelay UnlimitedMaxAhead PHigh
+        EnqueueAll NodeRelay (MaxAhead 1) PHigh
       ]
     go (MsgRequestBlock _) = [
         -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] (MaxAhead 1) PHigh
+        EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
       ]
     go (MsgMPC _) = [
         -- not relevant
@@ -283,7 +283,7 @@ defaultEnqueuePolicyEdgeExchange = go
       ]
     go (MsgRequestBlock _) = [
         -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] (MaxAhead 1) PHigh
+        EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
       ]
     go (MsgMPC _) = [
         -- not relevant
@@ -309,7 +309,7 @@ defaultEnqueuePolicyEdgeP2P = go
       ]
     go (MsgRequestBlock _) = [
         -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] (MaxAhead 1) PHigh
+        EnqueueOne [NodeRelay] UnlimitedMaxAhead PHigh
       ]
     go (MsgMPC _) = [
         -- not relevant

--- a/src/Network/Broadcast/OutboundQueue/Demo.hs
+++ b/src/Network/Broadcast/OutboundQueue/Demo.hs
@@ -140,9 +140,9 @@ relayDemo = do
 
       block "* Sending to specific nodes" nodeEs $ do
         -- This will send to the relay node
-        send Asynchronous nodeC1 (MsgRequestBlock (Set.fromList (nodeId <$> [nodeC2, nodeR]))) (MsgId 500)
+        send Asynchronous nodeC1 (MsgRequestBlocks (Set.fromList (nodeId <$> [nodeC2, nodeR]))) (MsgId 500)
         -- Edge nodes can never send to core nodes
-        send Asynchronous (nodeEs !! 0) (MsgRequestBlock (Set.fromList (nodeId <$> [nodeC1]))) (MsgId 501)
+        send Asynchronous (nodeEs !! 0) (MsgRequestBlocks (Set.fromList (nodeId <$> [nodeC1]))) (MsgId 501)
 
       logNotice "End of demo"
 
@@ -195,7 +195,7 @@ nodeForwardListener node = forever $ do
       let sender = msgSender msgData
           forwardMsgType = case msgType msgData of
             MsgAnnounceBlockHeader _ -> Just (MsgAnnounceBlockHeader (OriginForward sender))
-            MsgRequestBlock _ -> Nothing
+            MsgRequestBlocks _ -> Nothing
             MsgRequestBlockHeaders -> Nothing
             MsgTransaction _ -> Just (MsgTransaction (OriginForward sender))
             MsgMPC _ -> Just (MsgMPC (OriginForward sender))

--- a/src/Network/Broadcast/OutboundQueue/Types.hs
+++ b/src/Network/Broadcast/OutboundQueue/Types.hs
@@ -165,7 +165,7 @@ data MsgType nid =
   | MsgRequestBlockHeaders
 
     -- | Request for a specific block from these peers.
-  | MsgRequestBlock (Set nid)
+  | MsgRequestBlocks (Set nid)
 
     -- | New transaction
   | MsgTransaction (Origin nid)
@@ -178,13 +178,13 @@ msgOrigin :: MsgType nid -> Origin nid
 msgOrigin msg = case msg of
   MsgAnnounceBlockHeader origin -> origin
   MsgRequestBlockHeaders -> OriginSender
-  MsgRequestBlock _ -> OriginSender
+  MsgRequestBlocks _ -> OriginSender
   MsgTransaction origin -> origin
   MsgMPC origin -> origin
 
 msgEnqueueTo :: MsgType nid -> EnqueueTo nid
 msgEnqueueTo msg = case msg of
-  MsgRequestBlock peers -> EnqueueToSubset peers
+  MsgRequestBlocks peers -> EnqueueToSubset peers
   _ -> EnqueueToAll
 
 -- | Node types


### PR DESCRIPTION
This is a crucial PR, because in the policy as it had been implemented requests for block headers and requests for blocks were given the lowest priority. This would cause relay nodes that are inundated with transactions (which were given a higher priority) to never request blocks, therefore getting behind, finally entering recovery mode, and then being unable to exit recovery mode because transactions were also given higher priority than the "request headers" messages.
    
The original spec did not talk about these kinds of messages, but the newer specs do and indeed give them high priority. This PR brings the code in line with this spec, but there are still some open questions:
    
* I have increased the `MaxInFlight` values for core-to-relay, relay-to-core, and edge-to-relay communication to a minumum of 2. Otherwise we may run into deadlocks, as described in https://github.com/input-output-hk/cardano-sl/pull/1323 . That PR addresses the problem higher up the chain, but I worry that the same problem will arise elsewhere (in fact, we may wish to have a slightly higher minimum than 2 even).

* The policy docs do not give rules for header requests and block requests for edge nodes, and moreover gives transactions the highest priority (made sense, since only message considered).  This opens it up to the same problems as described above, however; therefore, I have given transactions a `PLow` transaction (P4), with requests for block headers and requests for blocks a `PHigh` priority (P2). This brings the policy here in line with core and relay nodes. For exchanges the policy gave P1 for header announcements and P2 for transactions; I have left the P1 as is, but here too made the transaction P4 and the requests for headers/blocks P2.
    
* I am worried about the low max-ahead value of 1 for requests for blocks and requests for headers. What happens when a node enters recovery mode, and tries to enqueue a whole series of block requests because it realizes it is far behind? It will quickly run out of peers to encode the requests to. Maybe this is what the "fallback: TODO" is about in the policy document. Therefore, I have set the max-ahead for block requests to infinite. I have however also makes a related change: when we have a choice, we pick a node with the smallest number of messages ahead. This means we at least get some load balancing when we do request a ton of blocks.

This PR also makes some minor fixes to logging; as @kantp and I were debugging, we discovered some minor inconsistencies in the logging that were confusing us.
