### PR TITLE
[CSL-1505] Do not define default policies; peer classification for non-routed peers

### DIFF
--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -664,7 +664,7 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
       enq@EnqueueAll{..} -> do
         let fwdSets :: AllOf (Alts nid)
             fwdSets = removeOrigin (msgOrigin msgType) $
-                        peers ^. peersOfType enqNodeType
+                        peersRoutes peers ^. routesOfType enqNodeType
 
             sendAll :: [Packet msg nid a]
                     -> AllOf (Alts nid)
@@ -697,7 +697,7 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
         let fwdSets :: [(NodeType, Alts nid)]
             fwdSets = concatMap
                         (\t -> map (t,) $ removeOrigin (msgOrigin msgType) $
-                                            peers ^. peersOfType t)
+                                            peersRoutes peers ^. routesOfType t)
                         enqNodeTypes
 
             -- We don't warn when choosing an alternative here, as failure to
@@ -1056,8 +1056,8 @@ intEnqueueTo outQ@OutQ{..} msgType msg enqTo = do
         EnqueueToAll           -> allPeers
         EnqueueToSubset subset ->
           let restricted = restrictPeers subset allPeers
-              unknown    = peersFromList
-                         . map (\nid -> (qUnknownNodeType nid, [nid]))
+              unknown    = peersFromList mempty
+                         . map (\nid -> (classifyNodeDefault allPeers (qUnknownNodeType nid) nid, [nid]))
                          . Set.toList
                          $ subset Set.\\ peersToSet allPeers
 

--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -36,25 +36,14 @@ module Network.Broadcast.OutboundQueue (
   , Enqueue(..)
   , EnqueuePolicy
   , UnknownNodeType(..)
-  , defaultEnqueuePolicy
-  , defaultEnqueuePolicyCore
-  , defaultEnqueuePolicyRelay
-  , defaultEnqueuePolicyEdgeBehindNat
-  , defaultEnqueuePolicyEdgeP2P
     -- ** Dequeueing policy
   , RateLimit(..)
   , MaxInFlight(..)
   , Dequeue(..)
   , DequeuePolicy
-  , defaultDequeuePolicy
-  , defaultDequeuePolicyCore
-  , defaultDequeuePolicyRelay
-  , defaultDequeuePolicyEdgeBehindNat
-  , defaultDequeuePolicyEdgeP2P
     -- ** Failure policy
   , FailurePolicy
   , ReconsiderAfter(..)
-  , defaultFailurePolicy
     -- ** Subscription
   , MaxBucketSize(..)
     -- * Enqueueing
@@ -92,7 +81,7 @@ import Data.Either (rights)
 import Data.Foldable (fold)
 import Data.List (sortBy, intercalate)
 import Data.Map.Strict (Map)
-import Data.Maybe (maybeToList, fromMaybe)
+import Data.Maybe (maybeToList)
 import Data.Monoid ((<>))
 import Data.Ord (comparing)
 import Data.Text (Text)
@@ -189,120 +178,6 @@ type EnqueuePolicy nid =
            MsgType nid  -- ^ Type of the message we want to send
         -> [Enqueue]
 
--- | Pick default policy given node type
---
--- NOTE: Assumes standard behind-NAT node in the case of edge nodes.
-defaultEnqueuePolicy :: NodeType -> EnqueuePolicy nid
-defaultEnqueuePolicy NodeCore  = defaultEnqueuePolicyCore
-defaultEnqueuePolicy NodeRelay = defaultEnqueuePolicyRelay
-defaultEnqueuePolicy NodeEdge  = defaultEnqueuePolicyEdgeBehindNat
-                                   Nothing -- default number of transactions
-
--- | Default enqueue policy for core nodes
-defaultEnqueuePolicyCore :: EnqueuePolicy nid
-defaultEnqueuePolicyCore = go
-  where
-    go :: EnqueuePolicy nid
-    go (MsgAnnounceBlockHeader _) = [
-        EnqueueAll NodeCore  (MaxAhead 0) PHighest
-      , EnqueueAll NodeRelay (MaxAhead 0) PHigh
-      ]
-    go MsgRequestBlockHeaders = [
-        EnqueueAll NodeCore  (MaxAhead 1) PHigh
-      , EnqueueAll NodeRelay (MaxAhead 1) PHigh
-      ]
-    go (MsgRequestBlocks _) = [
-        -- We never ask for data from edge nodes
-        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 1) PHigh
-      ]
-    go (MsgMPC _) = [
-        EnqueueAll NodeCore (MaxAhead 1) PMedium
-        -- not sent to relay nodes
-      ]
-    go (MsgTransaction _) = [
-        EnqueueAll NodeCore (MaxAhead 20) PLow
-        -- not sent to relay nodes
-      ]
-
--- | Default enqueue policy for relay nodes
-defaultEnqueuePolicyRelay :: EnqueuePolicy nid
-defaultEnqueuePolicyRelay = go
-  where
-    -- Enqueue policy for relay nodes
-    go :: EnqueuePolicy nid
-    go (MsgAnnounceBlockHeader _) = [
-        EnqueueAll NodeRelay (MaxAhead 0) PHighest
-      , EnqueueAll NodeCore  (MaxAhead 0) PHigh
-      , EnqueueAll NodeEdge  (MaxAhead 0) PMedium
-      ]
-    go MsgRequestBlockHeaders = [
-        EnqueueAll NodeCore  (MaxAhead 1) PHigh
-      , EnqueueAll NodeRelay (MaxAhead 1) PHigh
-      ]
-    go (MsgRequestBlocks _) = [
-        -- We never ask for blocks from edge nodes
-        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 1) PHigh
-      ]
-    go (MsgTransaction _) = [
-        EnqueueAll NodeCore  (MaxAhead 20) PLow
-      , EnqueueAll NodeRelay (MaxAhead 20) PLow
-        -- transactions not forwarded to edge nodes
-      ]
-    go (MsgMPC _) = [
-        -- Relay nodes never sent any MPC messages to anyone
-      ]
-
--- | Default enqueue policy for standard behind-NAT edge nodes
-defaultEnqueuePolicyEdgeBehindNat
-    :: Maybe MaxAhead -- ^ Maximum number of transactions ahead (default: 1)
-    -> EnqueuePolicy nid
-defaultEnqueuePolicyEdgeBehindNat mMaxTrans = go
-  where
-    -- Enqueue policy for edge nodes
-    go :: EnqueuePolicy nid
-    go (MsgTransaction OriginSender) = [
-        EnqueueAll NodeRelay (fromMaybe (MaxAhead 1) mMaxTrans) PLow
-      ]
-    go (MsgTransaction (OriginForward _)) = [
-        -- don't forward transactions that weren't created at this node
-      ]
-    go (MsgAnnounceBlockHeader _) = [
-        -- not forwarded
-      ]
-    go MsgRequestBlockHeaders = [
-        EnqueueAll NodeRelay (MaxAhead 0) PHigh
-      ]
-    go (MsgRequestBlocks _) = [
-        -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] (MaxAhead 0) PHigh
-      ]
-    go (MsgMPC _) = [
-        -- not relevant
-      ]
-
--- | Default enqueue policy for edge nodes using P2P
-defaultEnqueuePolicyEdgeP2P :: EnqueuePolicy nid
-defaultEnqueuePolicyEdgeP2P = go
-  where
-    -- Enqueue policy for edge nodes
-    go :: EnqueuePolicy nid
-    go (MsgTransaction _) = [
-        EnqueueAll NodeRelay (MaxAhead 3) PLow
-      ]
-    go (MsgAnnounceBlockHeader _) = [
-        EnqueueAll NodeRelay (MaxAhead 0) PHighest
-      ]
-    go MsgRequestBlockHeaders = [
-        EnqueueAll NodeRelay (MaxAhead 1) PHigh
-      ]
-    go (MsgRequestBlocks _) = [
-        -- Edge nodes can only talk to relay nodes
-        EnqueueOne [NodeRelay] (MaxAhead 1) PHigh
-      ]
-    go (MsgMPC _) = [
-        -- not relevant
-      ]
-
 {-------------------------------------------------------------------------------
   Dequeue policy
 -------------------------------------------------------------------------------}
@@ -329,56 +204,6 @@ newtype MaxInFlight = MaxInFlight Int
 -- not the same of the message we're sending.
 type DequeuePolicy = NodeType -> Dequeue
 
--- | Pick default dequeue policy for a given node
---
--- NOTE: Assumes standard behind-NAT in the case of edge nodes.
-defaultDequeuePolicy :: NodeType -> DequeuePolicy
-defaultDequeuePolicy NodeCore  = defaultDequeuePolicyCore
-defaultDequeuePolicy NodeRelay = defaultDequeuePolicyRelay
-defaultDequeuePolicy NodeEdge  = defaultDequeuePolicyEdgeBehindNat
-                                   Nothing -- use default MaxMsgPerSec
-                                   Nothing -- use default RateLimit
-
--- | Default dequeue policy for core nodes
-defaultDequeuePolicyCore :: DequeuePolicy
-defaultDequeuePolicyCore = go
-  where
-    go :: DequeuePolicy
-    go NodeCore  = Dequeue NoRateLimiting (MaxInFlight 3)
-    go NodeRelay = Dequeue NoRateLimiting (MaxInFlight 2)
-    go NodeEdge  = error "defaultDequeuePolicy: core to edge not applicable"
-
--- | Dequeueing policy for relay nodes
-defaultDequeuePolicyRelay :: DequeuePolicy
-defaultDequeuePolicyRelay = go
-  where
-    go :: DequeuePolicy
-    go NodeCore  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
-    go NodeRelay = Dequeue (MaxMsgPerSec 3) (MaxInFlight 2)
-    go NodeEdge  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
-
--- | Dequeueing policy for standard behind-NAT edge nodes
-defaultDequeuePolicyEdgeBehindNat
-    :: Maybe RateLimit    -- ^ Max messages per second (per thread); default: 1
-    -> Maybe MaxInFlight  -- ^ Max number of convs to the relay; default: 2
-    -> DequeuePolicy
-defaultDequeuePolicyEdgeBehindNat mMaxMsgPerSec mMaxInFlight = go
-  where
-    go :: DequeuePolicy
-    go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
-    go NodeRelay = Dequeue (fromMaybe (MaxMsgPerSec 1) mMaxMsgPerSec)
-                           (fromMaybe (MaxInFlight 2)  mMaxInFlight)
-    go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
-
--- | Dequeueing policy for P2P edge nodes
-defaultDequeuePolicyEdgeP2P :: DequeuePolicy
-defaultDequeuePolicyEdgeP2P = go
-  where
-    go :: DequeuePolicy
-    go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
-    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
-    go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
-
 {-------------------------------------------------------------------------------
   Failure policy
 -------------------------------------------------------------------------------}
@@ -390,13 +215,6 @@ type FailurePolicy nid = NodeType -> MsgType nid -> SomeException -> ReconsiderA
 
 -- | How long after a failure should we reconsider this node again?
 newtype ReconsiderAfter = ReconsiderAfter NominalDiffTime
-
--- | Default failure policy
---
--- TODO: Implement proper policy
-defaultFailurePolicy :: NodeType -- ^ Our node type
-                     -> FailurePolicy nid
-defaultFailurePolicy _ourType _theirType _msgType _err = ReconsiderAfter 200
 
 {-------------------------------------------------------------------------------
   Thin wrapper around ConcurrentMultiQueue


### PR DESCRIPTION
They've been moved to cardano-sl. ~~Will reference the pull request once it's been made.~~

https://github.com/input-output-hk/cardano-sl/pull/1347

Also included a commit to extend the `Peers` datatype with a classification of those peers which do not necessarily appear in the routing lists. This is useful because sometimes we route to peers even though they don't appear in our routing list, as in `MsgGetBlocks`.