### PR TITLE
[CSL-1515] decrement in flight before delay

### DIFF
--- a/src/Network/Broadcast/OutboundQueue/Demo.hs
+++ b/src/Network/Broadcast/OutboundQueue/Demo.hs
@@ -199,7 +199,7 @@ nodeForwardListener node = forever $ do
           forwardMsgType = case msgType msgData of
             MsgAnnounceBlockHeader _ -> Just (MsgAnnounceBlockHeader (OriginForward sender))
             MsgRequestBlocks _ -> Nothing
-            MsgRequestBlockHeaders -> Nothing
+            MsgRequestBlockHeaders _ -> Nothing
             MsgTransaction _ -> Just (MsgTransaction (OriginForward sender))
             MsgMPC _ -> Just (MsgMPC (OriginForward sender))
       case forwardMsgType of

--- a/src/Network/Broadcast/OutboundQueue/Types.hs
+++ b/src/Network/Broadcast/OutboundQueue/Types.hs
@@ -245,7 +245,8 @@ data MsgType nid =
     MsgAnnounceBlockHeader (Origin nid)
 
     -- | Request block headers (either specific range or the tip)
-  | MsgRequestBlockHeaders
+    -- Opitionally give a set of targets.
+  | MsgRequestBlockHeaders (Maybe (Set nid))
 
     -- | Request for a specific block from these peers.
   | MsgRequestBlocks (Set nid)
@@ -260,13 +261,14 @@ data MsgType nid =
 msgOrigin :: MsgType nid -> Origin nid
 msgOrigin msg = case msg of
   MsgAnnounceBlockHeader origin -> origin
-  MsgRequestBlockHeaders -> OriginSender
+  MsgRequestBlockHeaders _ -> OriginSender
   MsgRequestBlocks _ -> OriginSender
   MsgTransaction origin -> origin
   MsgMPC origin -> origin
 
 msgEnqueueTo :: MsgType nid -> EnqueueTo nid
 msgEnqueueTo msg = case msg of
+  MsgRequestBlockHeaders (Just peers) -> EnqueueToSubset peers
   MsgRequestBlocks peers -> EnqueueToSubset peers
   _ -> EnqueueToAll
 


### PR DESCRIPTION
Previously, a message which had been dequeued and completed would still
occupy space in the queue. How long it remains effectively in the queue
depends upon the rate limit. In cardano-sl a rate limit of 1 per second
is used, and so it was observed that a message would always stay in the
queue for at least one second. This caused recovery mode to fail. The
MsgRequestHeaders would hang around for ~0.8 seconds after the
conversation had finished, during which time two MsgRequestBlocks are
enqueued, but the second would fail because there's 2 message ahead of
it. Failing to get the needed blocks, the node would try again,
enqueuing a MsgRequestHeaders and repeating the cycle of failure.

## Update August 18

The problem arises in recovery mode. There's a block retrieval queue and one
thread (the retrieval worker) which clears it. This is in `Pos.Block.Network.Retrieval`.
If it pulls out a header which is determined to be for an alternate chain (alternate
meaning its parent is not our tip, so not necessarily a fork, just a header which
does not *immediately* continue our chain) then it will enter recovery mode via
`triggerRecovery`.

This term `triggerRecovery` is currently the only program to enqueue a
`MsgRequestBlockHeaders`. Find it in `Pos.Block.Network.Logic`. Within
the conversation is requests the peer's tip header (`requestTip`, same module)
and then classifies it and, if it's useful, puts it back into that retrieval queue.

There was never a problem with the `MsgRequestBlockHeaders` enqueueing.
It would typically work as expected, close up for all peers (`triggerRecovery`
would wait for all conversation to finish), and return to the retrieval worker.
The story so far is that we've found a header for an alternative chain, so we're
at `handleAlternative` in `Pos.Block.Network.Retrieval`. The recovery mode
`TMVar` is updated so that the rest of the system knows that recovery mode is
on, and then a `MsgRequestBlocks` is enqueued to the peer which gave us the
relevant header (the one that we put into the recovery `TMVar`).

That `MsgRequestBlocks` doesn't actually request blocks right away. Instead it
asks for more headers, hoping to use them to find the nearest ancestor in its own
chain. TW-161 proposes to use a `MsgRequestBlockHeaders` type here. Within that
conversation, `handleCHsValid` will be called which also enqueues a
`MsgRequestBlocks`, this time actually asking for the blocks themselves, for each
of the headers, from that same peer, and waits until the conversation finishes.
This is the nested `MsgRequestBlocks` conversation that was causing trouble.
Without these changes, the `MsgRequestBlockHeaders` from earlier was still
occupying space in the queue, so the second `MsgRequestBlocks` was denied
and recovery mode was judged a failure and restarted.

@dcoutts noticed that there's a potential for even more nesting! In `handleCHsValid`,
if there's an error retrieving the blocks, `triggerRecovery` will be entered yet again
via `dropRecoveryHeaderAndRepeat`! That's to say, `MsgRequestBlockHeaders`
will be enqueued and waited on within a `MsgRequestBlocks`, within a `MsgRequestBlocks`.