### PR TITLE
[CSL-1549] correct enqueue subset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_install:
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards
   --strip-components=1 -C ~/.local/bin '*/stack'
 install:
-- stack --no-terminal --install-ghc build --only-dependencies --jobs=1
+- stack --no-terminal --install-ghc build --only-dependencies --jobs=2 --fast
 script:
-- stack --no-terminal build --test --jobs=1 --flag node-sketch:benchmarks
+- stack --no-terminal build --test --jobs=2 --fast --flag node-sketch:benchmarks
 notifications:
   email: false
   slack:

--- a/src/Network/Broadcast/OutboundQueue/Types.hs
+++ b/src/Network/Broadcast/OutboundQueue/Types.hs
@@ -13,7 +13,8 @@ module Network.Broadcast.OutboundQueue.Types (
   , routesOfType
   , simplePeers
   , peersFromList
-  , peersToSet
+  , peersRouteSet
+  , peersSet
   , removePeer
   , restrictPeers
   , MsgType(..)
@@ -173,14 +174,19 @@ peersFromList notRouted = go start
               }
       in  go acc' altss
 
--- | Flatten 'Peers' structure
-peersToSet :: Ord nid => Peers nid -> Set nid
-peersToSet Peers{..} = Set.unions . concat $ [
+-- | The set of all peers which appear in a route.
+--   Always a subset of 'peersSet'.
+peersRouteSet :: Ord nid => Peers nid -> Set nid
+peersRouteSet Peers{..} = Set.unions . concat $ [
       map Set.fromList (_routesCore peersRoutes)
     , map Set.fromList (_routesRelay peersRoutes)
     , map Set.fromList (_routesEdge peersRoutes)
-    , [Map.keysSet peersClassification]
     ]
+
+-- | The set of all peers which are classified.
+--   Always a superset of 'peersRouteSet'
+peersSet :: Peers nid -> Set nid
+peersSet Peers{..} = Map.keysSet peersClassification
 
 instance Monoid (Routes nid) where
   mempty      = Routes [] [] []


### PR DESCRIPTION
Peers which are not routed in the queue's peers term now appear in the
'unknown' set and are appropriately classified and routed.