### PR TITLE
Restore setupMonitor

### DIFF
--- a/examples/PingPong.hs
+++ b/examples/PingPong.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE RankNTypes            #-}
 
 module Main where
 
@@ -20,14 +20,14 @@ import qualified Data.ByteString.Char8      as B8
 import           Data.Data                  (Data)
 import           Data.Time.Units            (Microsecond, fromMicroseconds)
 import           GHC.Generics               (Generic)
-import           Mockable.Concurrent        (delay, fork, killThread, forConcurrently)
+import           Mockable.Concurrent        (delay, forConcurrently, fork,
+                                             killThread)
 import           Mockable.Production
 import           Network.Transport.Abstract (closeTransport)
 import           Network.Transport.Concrete (concrete)
 import qualified Network.Transport.TCP      as TCP
 import           Node
 import           Node.Message.Binary        (BinaryP, binaryPacking)
-import           Node.Util.Monitor          (startMonitor)
 import           System.Random
 
 -- | Type for messages from the workers to the listeners.
@@ -107,11 +107,9 @@ main = runProduction $ do
     node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
          prng1 binaryPacking (B8.pack "I am node 1") defaultNodeEnvironment $ \node1 ->
         NodeAction (listeners . nodeId $ node1) $ \converse1 -> do
-            _ <- startMonitor 8000 runProduction node1
             node (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay)
                   prng2 binaryPacking (B8.pack "I am node 2") defaultNodeEnvironment $ \node2 ->
                 NodeAction (listeners . nodeId $ node2) $ \converse2 -> do
-                    _ <- startMonitor 8001 runProduction node2
                     tid1 <- fork $ worker (nodeId node1) prng3 [nodeId node2] converse1
                     tid2 <- fork $ worker (nodeId node2) prng4 [nodeId node1] converse2
                     liftIO . putStrLn $ "Hit return to stop"

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -45,6 +45,8 @@ Library
                         Node.Message.Class
                         Node.Message.Binary
 
+                        Node.Util.Monitor
+
                         NTP.Client
                         NTP.Example
 
@@ -99,6 +101,7 @@ Library
                       , unordered-containers
                       , semigroups
                       , ekg-core
+                      , ekg
                       , mwc-random
                       , statistics
                       , vector

--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -101,7 +101,6 @@ Library
                       , unordered-containers
                       , semigroups
                       , ekg-core
-                      , ekg
                       , mwc-random
                       , statistics
                       , vector

--- a/src/Node/Util/Monitor.hs
+++ b/src/Node/Util/Monitor.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GADTs #-}
 
 module Node.Util.Monitor (
-      setupMonitor
+      registerMetrics
     ) where
 
 import Control.Monad.IO.Class
@@ -19,7 +19,7 @@ import Node
 -- | Put time-warp related metrics into an EKG store.
 --   You must indicate how to run the monad into IO, so that EKG can produce
 --   the metrics (it works in IO).
-setupMonitor
+registerMetrics
     :: ( Mockable Metrics.Metrics m
        , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
        , MonadIO m
@@ -29,7 +29,7 @@ setupMonitor
     -> Node m
     -> Monitoring.Store
     -> m ()
-setupMonitor mbNamespace lowerIO node store = do
+registerMetrics mbNamespace lowerIO node store = do
     liftIO $ flip (Monitoring.registerGauge (withNamespace "handlers.initiated_remotely")) store $ lowerIO $ do
         stats <- nodeStatistics node
         Metrics.readGauge (stRunningHandlersRemote stats)

--- a/src/Node/Util/Monitor.hs
+++ b/src/Node/Util/Monitor.hs
@@ -4,18 +4,14 @@
 {-# LANGUAGE GADTs #-}
 
 module Node.Util.Monitor (
-
       setupMonitor
-    , startMonitor
-    , stopMonitor
-
     ) where
 
 import Control.Monad.IO.Class
-import Control.Concurrent (killThread)
 import Mockable.Class
+import qualified Data.Text as T
+import Data.Monoid ((<>))
 import qualified Mockable.Metrics as Metrics
-import qualified System.Remote.Monitoring as Monitoring
 import qualified System.Metrics as Monitoring
 import qualified System.Metrics.Distribution as Monitoring.Distribution
 import Node
@@ -28,44 +24,27 @@ setupMonitor
        , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
        , MonadIO m
        )
-    => (forall t . m t -> IO t)
+    => Maybe T.Text
+    -> (forall t . m t -> IO t)
     -> Node m
     -> Monitoring.Store
     -> m Monitoring.Store
-setupMonitor lowerIO node store = do
-    liftIO $ flip (Monitoring.registerGauge "Remotely-initated handlers") store $ lowerIO $ do
+setupMonitor mbNamespace lowerIO node store = do
+    liftIO $ flip (Monitoring.registerGauge (withNamespace "handlers.initiated_remotely")) store $ lowerIO $ do
         stats <- nodeStatistics node
         Metrics.readGauge (stRunningHandlersRemote stats)
-    liftIO $ flip (Monitoring.registerGauge "Locally-initated handlers") store $ lowerIO $ do
+    liftIO $ flip (Monitoring.registerGauge (withNamespace "handlers.initiated_locally")) store $ lowerIO $ do
         stats <- nodeStatistics node
         Metrics.readGauge (stRunningHandlersLocal stats)
-    liftIO $ flip (Monitoring.registerDistribution "Handler elapsed time (normal)") store $ lowerIO $ do
+    liftIO $ flip (Monitoring.registerDistribution (withNamespace "handlers.finished_normally.elapsed_time_microseconds")) store $ lowerIO $ do
         stats <- nodeStatistics node
         liftIO $ Monitoring.Distribution.read (stHandlersFinishedNormally stats)
-    liftIO $ flip (Monitoring.registerDistribution "Handler elapsed time (exceptional)") store $ lowerIO $ do
+    liftIO $ flip (Monitoring.registerDistribution (withNamespace "handlers.finished_exceptionally.elapsed_time_microseconds")) store $ lowerIO $ do
         stats <- nodeStatistics node
         liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
     return store
-
-startMonitor
-    :: ( Mockable Metrics.Metrics m
-       , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
-       , MonadIO m
-       )
-    => Int
-    -> (forall t . m t -> IO t)
-    -> Node m
-    -> m Monitoring.Server
-startMonitor port lowerIO node = do
-    store <- liftIO Monitoring.newStore
-    store' <- setupMonitor lowerIO node store
-    liftIO $ Monitoring.registerGcMetrics store'
-    server <- liftIO $ Monitoring.forkServerWith store "127.0.0.1" port
-    liftIO . putStrLn $ "Forked EKG server on port " ++ show port
-    return server
-
-stopMonitor
-    :: ( MonadIO m )
-    => Monitoring.Server
-    -> m ()
-stopMonitor server = liftIO $ killThread (Monitoring.serverThreadId server)
+  where
+      withNamespace :: T.Text -> T.Text
+      withNamespace name = case mbNamespace of
+          Nothing -> name
+          Just ns -> ns <> "." <> name

--- a/src/Node/Util/Monitor.hs
+++ b/src/Node/Util/Monitor.hs
@@ -1,0 +1,71 @@
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs #-}
+
+module Node.Util.Monitor (
+
+      setupMonitor
+    , startMonitor
+    , stopMonitor
+
+    ) where
+
+import Control.Monad.IO.Class
+import Control.Concurrent (killThread)
+import Mockable.Class
+import qualified Mockable.Metrics as Metrics
+import qualified System.Remote.Monitoring as Monitoring
+import qualified System.Metrics as Monitoring
+import qualified System.Metrics.Distribution as Monitoring.Distribution
+import Node
+
+-- | Put time-warp related metrics into an EKG store.
+--   You must indicate how to run the monad into IO, so that EKG can produce
+--   the metrics (it works in IO).
+setupMonitor
+    :: ( Mockable Metrics.Metrics m
+       , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
+       , MonadIO m
+       )
+    => (forall t . m t -> IO t)
+    -> Node m
+    -> Monitoring.Store
+    -> m Monitoring.Store
+setupMonitor lowerIO node store = do
+    liftIO $ flip (Monitoring.registerGauge "Remotely-initated handlers") store $ lowerIO $ do
+        stats <- nodeStatistics node
+        Metrics.readGauge (stRunningHandlersRemote stats)
+    liftIO $ flip (Monitoring.registerGauge "Locally-initated handlers") store $ lowerIO $ do
+        stats <- nodeStatistics node
+        Metrics.readGauge (stRunningHandlersLocal stats)
+    liftIO $ flip (Monitoring.registerDistribution "Handler elapsed time (normal)") store $ lowerIO $ do
+        stats <- nodeStatistics node
+        liftIO $ Monitoring.Distribution.read (stHandlersFinishedNormally stats)
+    liftIO $ flip (Monitoring.registerDistribution "Handler elapsed time (exceptional)") store $ lowerIO $ do
+        stats <- nodeStatistics node
+        liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
+    return store
+
+startMonitor
+    :: ( Mockable Metrics.Metrics m
+       , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
+       , MonadIO m
+       )
+    => Int
+    -> (forall t . m t -> IO t)
+    -> Node m
+    -> m Monitoring.Server
+startMonitor port lowerIO node = do
+    store <- liftIO Monitoring.newStore
+    store' <- setupMonitor lowerIO node store
+    liftIO $ Monitoring.registerGcMetrics store'
+    server <- liftIO $ Monitoring.forkServerWith store "127.0.0.1" port
+    liftIO . putStrLn $ "Forked EKG server on port " ++ show port
+    return server
+
+stopMonitor
+    :: ( MonadIO m )
+    => Monitoring.Server
+    -> m ()
+stopMonitor server = liftIO $ killThread (Monitoring.serverThreadId server)

--- a/src/Node/Util/Monitor.hs
+++ b/src/Node/Util/Monitor.hs
@@ -28,7 +28,7 @@ setupMonitor
     -> (forall t . m t -> IO t)
     -> Node m
     -> Monitoring.Store
-    -> m Monitoring.Store
+    -> m ()
 setupMonitor mbNamespace lowerIO node store = do
     liftIO $ flip (Monitoring.registerGauge (withNamespace "handlers.initiated_remotely")) store $ lowerIO $ do
         stats <- nodeStatistics node
@@ -42,7 +42,6 @@ setupMonitor mbNamespace lowerIO node store = do
     liftIO $ flip (Monitoring.registerDistribution (withNamespace "handlers.finished_exceptionally.elapsed_time_microseconds")) store $ lowerIO $ do
         stats <- nodeStatistics node
         liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
-    return store
   where
       withNamespace :: T.Text -> T.Text
       withNamespace name = case mbNamespace of


### PR DESCRIPTION
This PR restores `Node.Util.Monitor`, but only `setupMonitor`.

This allows us to still drop `ekg`.

cc @dcoutts 