### PR TITLE
Use newer universum, log-warper, LTS

### DIFF
--- a/bench/LogReader/Main.hs
+++ b/bench/LogReader/Main.hs
@@ -33,7 +33,7 @@ import           Bench.Network.Commons        (LogMessage (..), MeasureEvent (..
 import           LogReaderOptions             (Args (..), argsParser)
 import           System.Wlog                  (LoggerNameBox, Severity (Info),
                                                initTerminalLogging, logError, logWarning,
-                                               usingLoggerName, usingLoggerName)
+                                               usingLoggerName)
 
 
 type Measures = M.Map MsgId (Payload, [(MeasureEvent, Timestamp)])
@@ -127,7 +127,7 @@ getOptions = (\(a, ()) -> a) <$> simpleOptions
 
 main :: IO ()
 main = usingLoggerName mempty $ do
-    initTerminalLogging True (Just Info)
+    initTerminalLogging True True (Just Info)
     Args{..} <- liftIO getOptions
     measures <- flip execStateT M.empty $
         forM_ inputFiles analyze

--- a/src/JsonLog/JsonLogT.hs
+++ b/src/JsonLog/JsonLogT.hs
@@ -44,7 +44,7 @@ import Serokell.Util.Lens             (WrappedM (..))
 import System.IO                      (Handle)
 import System.Wlog.CanLog             (CanLog, WithLogger, logWarning)
 import System.Wlog.LoggerNameBox      (HasLoggerName (..))
-import Universum                      hiding (catchAll)
+import Universum
 
 import JsonLog.CanJsonLog             (CanJsonLog (..))
 import JsonLog.Event                  (JLTimedEvent, toEvent, timedIO)

--- a/src/NTP/Example.hs
+++ b/src/NTP/Example.hs
@@ -26,6 +26,6 @@ type WorkMode = LoggerNameBox Production
 
 runNtpClientIO :: NtpClientSettings WorkMode -> IO ()
 runNtpClientIO settings = do
-    initTerminalLogging True (Just Debug)
+    initTerminalLogging True True (Just Debug)
     void $ runProduction $ usingLoggerName "ntp-example" $
         startNtpClient settings

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.5
+resolver: lts-9.1
 
 flags:
   ether:
@@ -28,14 +28,14 @@ nix:
 
 extra-deps:
   - ether-0.5.1.0
-  - log-warper-1.0.2
-  - serokell-util-0.1.3.5
-  - store-0.4.3.1
+  - log-warper-1.2.0
+  - serokell-util-0.5.0
   - time-units-1.0.0
   - transformers-lift-0.2.0.1
-  - universum-0.3
+  - universum-0.6.1
   - writer-cps-mtl-0.1.1.4
   - writer-cps-transformers-0.1.1.3
+  - acid-state-0.14.3
 
 flags: {}
 extra-package-dbs: []

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -44,7 +44,7 @@ import           Control.Exception           (Exception, SomeException (..))
 import           Control.Lens                (makeLenses, (%=))
 import           Control.Monad               (forM_, void)
 import           Control.Monad.IO.Class      (MonadIO (..))
-import           Control.Monad.State         (StateT)
+import           Control.Monad.State.Strict  (StateT)
 import           Data.Binary                 (Binary (..))
 import qualified Data.ByteString             as LBS
 import qualified Data.List                   as L


### PR DESCRIPTION
I need newer universum in cardano-sl. It requires to also bump log-warper and there was a breaking change there, so I need to bump it here.
I also updated LTS to be the same as the one in cardano-sl.