### PR TITLE
[CSL-1645] connectToPeer bracketing

### DIFF
--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -37,7 +37,6 @@ module Node.Internal (
     nodeStatistics,
     ChannelIn(..),
     ChannelOut(..),
-    closeChannel,
     startNode,
     stopNode,
     withInOutChannel,
@@ -242,9 +241,6 @@ newtype ChannelIn m = ChannelIn (Channel.ChannelT m (Maybe BS.ByteString))
 
 -- | Output to the wire.
 newtype ChannelOut m = ChannelOut (NT.Connection m)
-
-closeChannel :: ChannelOut m -> m ()
-closeChannel (ChannelOut conn) = NT.close conn
 
 -- | Do multiple sends on a 'ChannelOut'.
 writeMany

--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -1064,9 +1064,8 @@ nodeDispatcher node handlerInOut =
                           chanVar <- newSharedAtomic (Just channel)
                           let dumpBytes mBytes = withSharedAtomic chanVar $
                                   maybe (return ()) (flip Channel.writeChannel mBytes)
-                          let provenance = Remote peer connid
-                          let acquire = connectToPeer node (NodeId peer)
-                          let respondAndHandle conn = do
+                              provenance = Remote peer connid
+                              respondAndHandle conn = do
                                   outcome <- NT.send conn [controlHeaderBidirectionalAck nonce]
                                   case outcome of
                                       Left err -> throw err
@@ -1075,17 +1074,16 @@ nodeDispatcher node handlerInOut =
                           -- Resource releaser for bracketWithException.
                           -- No matter what, we must update the node state to
                           -- indicate that we've disconnected from the peer.
-                          let cleanup conn (me :: Maybe SomeException) = do
+                              cleanup (me :: Maybe SomeException) = do
                                   modifySharedAtomic chanVar $ \_ -> return (Nothing, ())
-                                  disconnectFromPeer node (NodeId peer) conn
                                   case me of
                                       Nothing -> return ()
                                       Just e -> logError $
                                           sformat (shown % " error in conversation response " % shown) nonce e
-                          let handler = bracketWithException
-                                            acquire
-                                            cleanup
-                                            respondAndHandle
+                              handler = bracketWithException
+                                  (return ())
+                                  (const cleanup)
+                                  (const (connectToPeer node (NodeId peer) respondAndHandle))
                           -- Establish the other direction in a separate thread.
                           (_, incrBytes) <- spawnHandler nstate provenance handler
                           let bs = LBS.toStrict ws'
@@ -1449,9 +1447,7 @@ withInOutChannel node@Node{nodeEnvironment, nodeState} nodeid@(NodeId peer) acti
                       cancelWith promise Timeout
                 }
             wait promise
-    bracket (connectToPeer node nodeid)
-            (\conn -> disconnectFromPeer node nodeid conn >> closeChannel)
-            action'
+    connectToPeer node nodeid action' `finally` closeChannel
 
 data OutboundConnectionState m =
       -- | A stable outbound connection has some positive number of established
@@ -1579,12 +1575,9 @@ disconnectFromPeer Node{nodeState} (NodeId peer) conn =
 --   other connections to that peer. Subsequent connections to that peer
 --   will block until the peer-data is sent; it must be the first thing to
 --   arrive when the first lightweight connection to a peer is opened.
---
---   A use of `connectToPeer` must be followed by `disconnectFromPeer`, in order
---   to keep the node state consistent. Please use safe exceptional handling
---   functions like `bracket` to make this guarantee.
 connectToPeer
-    :: ( Mockable Throw m
+    :: forall packingType peerData m r .
+       ( Mockable Throw m
        , Mockable Bracket m
        , Mockable SharedAtomic m
        , Mockable SharedExclusive m
@@ -1593,11 +1586,18 @@ connectToPeer
        )
     => Node packingType peerData m
     -> NodeId
-    -> m (NT.Connection m)
-connectToPeer Node{nodeEndPoint, nodeState, nodePacking, nodePeerData, nodeEnvironment} (NodeId peer) = do
-    conn <- establish
-    sendPeerDataIfNecessary conn
-    return conn
+    -> (NT.Connection m -> m r)
+    -> m r
+connectToPeer node@Node{nodeEndPoint, nodeState, nodePacking, nodePeerData, nodeEnvironment} nid@(NodeId peer) act =
+    -- 'establish' will update shared state indicating the nature of
+    -- connections to this peer: how many are coming up, going down, or
+    -- established. It's essential to bracket that against 'disconnectFromPeer'
+    -- so that if there's an exception when sending the peer data or when
+    -- doing the 'act' continuation, the state is always brought back to
+    -- consistency.
+    bracket establish (disconnectFromPeer node nid) $ \conn -> do
+        sendPeerDataIfNecessary conn
+        act conn
 
     where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@ packages:
     extra-dep: true
   - location:
       git: https://github.com/serokell/network-transport-tcp
-      commit: a6c04c35f3a1d786bc5e57fd04cf3e2a043179f3
+      commit: 3d56652123bd296dc759cd31947eb2a17924e68a # csl-0.6.0
     extra-dep: true
   - location:
       git: https://github.com/avieth/network-transport-inmemory


### PR DESCRIPTION
Previously it was required that the programmer correctly bracket
connectToPeer against disconnectFromPeer. But that was a losing battle:
it was impossible to do it right, because connectToPeer was too big to
use as the acquire part of a bracket against disconnectFromPeer: it was
possible that the shared state would be updated with a stable
established connection, but the whole action still exit with an exception
(at sendPeerDataIfNecessary). That would cause disconnectFromPeer not to
run, leaving an inconsistent state. Consequently, the peers would be
unable to communicate, as they would not agree on whether the peer data
needs to be transmitted.