### PR TITLE
[CSL-1652] Improve removePeer

### DIFF
--- a/node-sketch.cabal
+++ b/node-sketch.cabal
@@ -85,6 +85,7 @@ Library
                       , network-transport
                       , network-transport-tcp
                       , mtl >= 2.2.1
+                      , QuickCheck
                       , random
                       , resourcet
                       , transformers-lift

--- a/src/Network/Broadcast/OutboundQueue/Types.hs
+++ b/src/Network/Broadcast/OutboundQueue/Types.hs
@@ -233,10 +233,7 @@ removePeer toRemove peers =
     -- Removes the peer `toRemove` from the list of alternatives, skipping
     -- any empty list encountered, which is discarded as meaningless information.
     remove :: AllOf (Alts nid) -> AllOf (Alts nid)
-    remove [] = []
-    remove (x:xs) = case filter (/= toRemove) x of
-        [] -> remove xs
-        l  -> l : remove xs
+    remove = filter (not . null) . map (filter (/= toRemove))
 
 {-------------------------------------------------------------------------------
   Classification of messages and destinations

--- a/src/Network/Broadcast/OutboundQueue/Types.hs
+++ b/src/Network/Broadcast/OutboundQueue/Types.hs
@@ -32,6 +32,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Maybe (mapMaybe)
 import Control.Lens
+import Test.QuickCheck as QC
 import Formatting
 
 -- | Node types
@@ -62,8 +63,10 @@ data NodeType =
     -- * never create currency transactions
     -- * can communicate with core nodes
   | NodeRelay
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Bounded, Enum)
 
+instance Arbitrary NodeType where
+    arbitrary = QC.elements [minBound .. maxBound]
 
 {-------------------------------------------------------------------------------
   Known peers
@@ -87,6 +90,9 @@ data Peers nid = Peers {
     }
     deriving (Show, Eq)
 
+instance (Ord nid, Arbitrary nid) => Arbitrary (Peers nid) where
+    arbitrary = Peers <$> arbitrary <*> arbitrary
+
 classifyNode :: Ord nid => Peers nid -> nid -> Maybe NodeType
 classifyNode Peers {..} nid = Map.lookup nid peersClassification
 
@@ -100,6 +106,11 @@ data Routes nid = Routes {
     , _routesEdge  :: AllOf (Alts nid)
     }
   deriving (Show, Eq)
+
+instance Arbitrary nid => Arbitrary (Routes nid) where
+    arbitrary = Routes <$> arbitrary
+                       <*> arbitrary
+                       <*> arbitrary
 
 -- | List of forwarding sets
 --
@@ -219,8 +230,13 @@ removePeer toRemove peers =
             , peersClassification = classification'
             }
   where
+    -- Removes the peer `toRemove` from the list of alternatives, skipping
+    -- any empty list encountered, which is discarded as meaningless information.
     remove :: AllOf (Alts nid) -> AllOf (Alts nid)
-    remove = map $ filter (/= toRemove)
+    remove [] = []
+    remove (x:xs) = case filter (/= toRemove) x of
+        [] -> remove xs
+        l  -> l : remove xs
 
 {-------------------------------------------------------------------------------
   Classification of messages and destinations

--- a/test/Test/Network/Broadcast/OutboundQueueSpec.hs
+++ b/test/Test/Network/Broadcast/OutboundQueueSpec.hs
@@ -6,6 +6,7 @@ module Test.Network.Broadcast.OutboundQueueSpec
 import           Control.Monad
 import           Data.List                             (delete)
 import qualified Data.Map.Strict                       as M
+import qualified Data.Set                              as Set
 import qualified Mockable                              as M
 import qualified Network.Broadcast.OutboundQueue       as OutQ
 import           Network.Broadcast.OutboundQueue.Demo
@@ -13,7 +14,11 @@ import           Network.Broadcast.OutboundQueue.Types hiding (simplePeers)
 import           System.Wlog
 import           Test.Hspec                            (Spec, describe, it)
 import           Test.Hspec.QuickCheck                 (modifyMaxSuccess)
-import           Test.QuickCheck                       (ioProperty)
+import           Test.QuickCheck                       (Arbitrary (..),
+                                                        Property, choose,
+                                                        forAll, ioProperty,
+                                                        (===),
+                                                        property, (==>))
 
 -- disable logging
 testInFlight :: IO Bool
@@ -44,8 +49,45 @@ allGreaterThanZero :: M.Map NodeId (M.Map OutQ.Precedence Int) -> Bool
 allGreaterThanZero imap = all (>= 0) $ (concatMap M.elems (M.elems imap))
 
 spec :: Spec
-spec = describe "OutBoundQ" $ modifyMaxSuccess (const 100) $ do
-  -- Simulate a multi-peer conversation and then check
-  -- that after that we never have a negative count for
-  -- the `qInFlight` field of a `OutBoundQ`.
-  it "inflight conversations" $ ioProperty $ testInFlight
+spec = describe "OutBoundQ" $ do
+    -- We test that `removePeer` will never yield something like
+    -- `[[]]`. See: https://issues.serokell.io/issue/CSL-1652
+    it "removePeer doesn't yield empty singletons" $ property prop_removePeer
+    it "removePeer does preserve order" $ property prop_removePeer_ordering
+
+    modifyMaxSuccess (const 100) $ do
+      -- Simulate a multi-peer conversation and then check
+      -- that after that we never have a negative count for
+      -- the `qInFlight` field of a `OutBoundQ`.
+      it "inflight conversations" $ ioProperty $ testInFlight
+
+newtype FiniteInt = FI Int deriving (Show, Eq, Ord)
+
+instance Arbitrary FiniteInt where
+    arbitrary = FI <$> choose (0, 1024)
+
+finiteToList :: [FiniteInt] -> [Int]
+finiteToList = map (\(FI x) -> x)
+
+prop_removePeer :: Property
+prop_removePeer = forAll arbitrary $ \(peers :: Peers FiniteInt) ->
+    forAll arbitrary $ \(toRemove :: FiniteInt) ->
+       toRemove `Set.member` peersRouteSet peers ==>
+         let Peers{..} = removePeer toRemove peers
+         in and $ map checkProp [_routesCore peersRoutes, _routesEdge peersRoutes , _routesRelay peersRoutes]
+  where
+    checkProp = all (not . null . finiteToList)
+
+-- We purposefully try to remove something which is not there, to make sure
+-- removePeer doesn't alter the ordering of the forwading sets.
+prop_removePeer_ordering :: Property
+prop_removePeer_ordering = forAll arbitrary $ \(peers :: Peers FiniteInt) ->
+         let stripped = filterEmptySingletons peers
+             peers' = removePeer (FI 2000) stripped
+         in  peers' === stripped
+  where
+    filterEmptySingletons p =
+      let newRoutes = Routes (filter (not . null) (_routesCore . peersRoutes $ p))
+                             (filter (not . null) (_routesRelay . peersRoutes $ p))
+                             (filter (not . null) (_routesEdge . peersRoutes $ p))
+      in p { peersRoutes = newRoutes }


### PR DESCRIPTION
This maybe-over-complicated PR improves `removePeer` to skip empty lists.

See here for the full rational and debugging: https://issues.serokell.io/issue/CSL-1652#comment=96-7493

I have also added a bunch of properties to demonstrate this was indeed an issue prior to this patch:

![screen shot 2017-09-20 at 16 56 24](https://user-images.githubusercontent.com/29383371/30652396-9324a0e8-9e28-11e7-854a-00916a4fbacc.png)

But that now everything is green:

![screen shot 2017-09-20 at 17 24 53](https://user-images.githubusercontent.com/29383371/30652419-a2e52070-9e28-11e7-9f31-4be865244df9.png)
