### PR TITLE
[CSL-1702] Drop queue name from EKG metrics

### DIFF
--- a/src/Network/Broadcast/OutboundQueue.hs
+++ b/src/Network/Broadcast/OutboundQueue.hs
@@ -681,10 +681,9 @@ registerQueueMetrics namespaceMb OutQ{..} store = do
         -- correctly namespaced.
         -- E.g.
         -- let namespaceMb = Just "mynamespace"
-        -- let qSelf       = "test"
         -- metric ["InFlight"]
-        -- >>> mynamespace.queue.test.InFlight
-        let prefix = maybeToList namespaceMb ++ ["queue", qSelf]
+        -- >>> mynamespace.test.InFlight
+        let prefix = maybeToList namespaceMb ++ ["queue"]
         in T.pack . intercalate "." . (prefix ++)
 
 countInFlight :: InFlight nid -> Int


### PR DESCRIPTION
This simple PR drops the queue name (i.e. `qSelf`) from the EKG metrics.

@domenkozar This is how the dashboard will look like when we update Cardano accordingly:

![screen shot 2017-09-27 at 09 45 08](https://user-images.githubusercontent.com/29383371/30901611-d2723acc-a368-11e7-800b-78e0db7db7ae.png)

Good enough?