### PR TITLE
[CSL-1709] Log the reason why the connection was lost.

### DIFF
--- a/src/Node/Internal.hs
+++ b/src/Node/Internal.hs
@@ -835,7 +835,8 @@ nodeDispatcher node handlerInOut =
 
           -- When a heavyweight connection is lost we must close up all of the
           -- lightweight connections which it carried.
-          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode (NT.EventConnectionLost peer bundle)) _msg) ->
+          NT.ErrorEvent (NT.TransportError (NT.EventErrorCode (NT.EventConnectionLost peer bundle)) reason) -> do
+              logError $ sformat ("EventConnectionLost received from the network layer: " % shown) reason
               connectionLost state peer bundle >>= loop
 
           -- Unsupported event is recoverable. Just log and carry on.


### PR DESCRIPTION
This tiny PR stems from a conversation with @avieth and from [CSL-1709](https://issues.serokell.io/issue/CSL-1709). In order to troubleshoot and debug some subtle issues, it's nice to get as many logging as we can of the underlying error causes.

In particular, this PR logs the reason why a connection was lost. Hopefully it will be enough to track down the place inside `network-transport-tcp` where this is coming from (and why), to understand better what's going on.

Feel free to add more useful logging as part of this PR.