### PR TITLE
[CSL-1739] Bump up log-warper to 1.3.0

### DIFF
--- a/bench/LogReader/Main.hs
+++ b/bench/LogReader/Main.hs
@@ -34,6 +34,7 @@ import           LogReaderOptions             (Args (..), argsParser)
 import           System.Wlog                  (LoggerNameBox, Severity (Info),
                                                initTerminalLogging, logError, logWarning,
                                                usingLoggerName)
+import           System.Wlog.Formatter        (centiUtcTimeF)
 
 
 type Measures = M.Map MsgId (Payload, [(MeasureEvent, Timestamp)])
@@ -127,7 +128,7 @@ getOptions = (\(a, ()) -> a) <$> simpleOptions
 
 main :: IO ()
 main = usingLoggerName mempty $ do
-    initTerminalLogging True True (Just Info)
+    initTerminalLogging centiUtcTimeF True True (Just Info)
     Args{..} <- liftIO getOptions
     measures <- flip execStateT M.empty $
         forM_ inputFiles analyze

--- a/src/Bench/Network/Commons.hs
+++ b/src/Bench/Network/Commons.hs
@@ -99,7 +99,7 @@ loadLogConfig :: MonadIO m => Maybe FilePath -> Maybe FilePath -> m ()
 loadLogConfig logsPrefix configFile = do
     let cfgBuilder = productionB <> (mempty { _lcFilePrefix = logsPrefix })
     loggerConfig <- maybe (return defaultLogConfig) parseLoggerConfig configFile
-    setupLogging $ loggerConfig <> cfgBuilder
+    setupLogging Nothing $ loggerConfig <> cfgBuilder
 
 
 -- * Logging & parsing

--- a/src/NTP/Example.hs
+++ b/src/NTP/Example.hs
@@ -13,19 +13,20 @@ module NTP.Example
     -- there is no stop button, since `runNtpClientIO` does `initLogging`
     ) where
 
-import           Control.Monad       (void)
-import           Data.Default        (def)
-import           System.Wlog         (LoggerNameBox, Severity (..), initTerminalLogging,
-                                      usingLoggerName)
+import           Control.Monad         (void)
+import           Data.Default          (def)
+import           System.Wlog           (LoggerNameBox, Severity (..), initTerminalLogging,
+                                        usingLoggerName)
+import           System.Wlog.Formatter (centiUtcTimeF)
 
-import           Mockable.Instances  ()
-import           Mockable.Production (Production (..))
-import           NTP.Client          (NtpClientSettings (..), startNtpClient)
+import           Mockable.Instances    ()
+import           Mockable.Production   (Production (..))
+import           NTP.Client            (NtpClientSettings (..), startNtpClient)
 
 type WorkMode = LoggerNameBox Production
 
 runNtpClientIO :: NtpClientSettings WorkMode -> IO ()
 runNtpClientIO settings = do
-    initTerminalLogging True True (Just Debug)
+    initTerminalLogging centiUtcTimeF True True (Just Debug)
     void $ runProduction $ usingLoggerName "ntp-example" $
         startNtpClient settings

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,8 +28,9 @@ nix:
 
 extra-deps:
   - ether-0.5.1.0
-  - log-warper-1.2.0
+  - log-warper-1.3.0
   - serokell-util-0.5.0
+  - fmt-0.5.0.0
   - time-units-1.0.0
   - transformers-lift-0.2.0.1
   - universum-0.6.1


### PR DESCRIPTION
This bump up is required to bump up `log-warper` in `cardano-sl`.