### PR TITLE
Fix space leak and bug in the implementation of insert in NonEmptySet

### DIFF
--- a/src/Data/NonEmptySet.hs
+++ b/src/Data/NonEmptySet.hs
@@ -26,9 +26,10 @@ singleton t = NonEmptySet t S.empty
 
 -- | Extend a 'NonEmptySet' by adding one element.
 insert :: Ord t => t -> NonEmptySet t -> NonEmptySet t
-insert t (NonEmptySet t' set) = case t `compare` t' of
+insert t nes@(NonEmptySet t' set) = case t `compare` t' of
     LT -> NonEmptySet t (S.insert t' set)
-    _  -> NonEmptySet t' (S.insert t set)
+    EQ -> nes
+    GT -> NonEmptySet t' (S.insert t set)
 
 -- | Remove an element from a 'NonEmptySet'. If it's the only element of the
 --   set, 'Nothing' is given.

--- a/src/Data/NonEmptySet.hs
+++ b/src/Data/NonEmptySet.hs
@@ -15,28 +15,28 @@ import           Data.List.NonEmpty (NonEmpty((:|)))
 import           Data.Foldable (foldrM)
 
 -- | A set (no duplicates) with at least one element.
-newtype NonEmptySet t = NonEmptySet (t, Set t)
+data NonEmptySet t = NonEmptySet !t !(Set t)
 
 instance Show t => Show (NonEmptySet t) where
     show = show . toList
 
 -- | Construct a 'NonEmptySet' by giving one element.
 singleton :: t -> NonEmptySet t
-singleton t = NonEmptySet (t, S.empty)
+singleton t = NonEmptySet t S.empty
 
 -- | Extend a 'NonEmptySet' by adding one element.
 insert :: Ord t => t -> NonEmptySet t -> NonEmptySet t
-insert t (NonEmptySet (t', set)) = case t `compare` t' of
-    LT -> NonEmptySet (t, S.insert t' set)
-    _ -> NonEmptySet (t', S.insert t set)
+insert t (NonEmptySet t' set) = case t `compare` t' of
+    LT -> NonEmptySet t (S.insert t' set)
+    _  -> NonEmptySet t' (S.insert t set)
 
 -- | Remove an element from a 'NonEmptySet'. If it's the only element of the
 --   set, 'Nothing' is given.
 delete :: Ord t => t -> NonEmptySet t -> Maybe (NonEmptySet t)
-delete t (NonEmptySet (t', set)) = case (t == t', S.minView set) of
-    (False, _) -> Just $ NonEmptySet (t', S.delete t set)
+delete t (NonEmptySet t' set) = case (t == t', S.minView set) of
+    (False, _) -> Just $ NonEmptySet t' (S.delete t set)
     (True, Nothing) -> Nothing
-    (True, Just (t'', set')) -> Just (NonEmptySet (t'', set'))
+    (True, Just (t'', set')) -> Just $ NonEmptySet t'' set'
 
 deleteMany :: Ord t => [t] -> NonEmptySet t -> Maybe (NonEmptySet t)
 deleteMany ts neset = foldrM delete neset ts
@@ -44,4 +44,4 @@ deleteMany ts neset = foldrM delete neset ts
 -- | Forget the fact that a 'NonEmptySet' and construct a 'NonEmpty' list, in
 --   which duplicates *are* allowed.
 toList :: NonEmptySet t -> NonEmpty t
-toList (NonEmptySet (t, set)) = t :| S.toList set
+toList (NonEmptySet t set) = t :| S.toList set


### PR DESCRIPTION
The first commit alters the implementation of NonEmptySet so that `Node.Internal.nodeDispatcher` doesn't leak space anymore. The second one fixes a bug in the implementation of `insert` where you could end up with two equal elements in the set.